### PR TITLE
Enhance docs and walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # the‑block
 
 > **A formally‑specified, dual‑token blockchain kernel written in Rust with first‑class Python bindings.**  Zero unsafe code, deterministic serialization, cross‑platform builds, one‑command bootstrap.
+> Built from day one for real-world deployment; every example uses the same APIs shipped to production nodes.
 
 ---
 

--- a/demo.py
+++ b/demo.py
@@ -1,87 +1,110 @@
+"""Interactive walkthrough showcasing core features of The‑Block.
+
+Run this script from a terminal to see how a fresh chain is created,
+transactions are signed, and blocks are mined. Explanatory text is
+printed at each step so no prior blockchain knowledge is required.
+
+This script exercises the same production-grade APIs used by real
+nodes, illustrating how wallet software can interact with the chain.
+"""
+
 import os
 import shutil
+
 import the_block
 
-def main():
-    print("==> Initializing blockchain…")
+
+def explain(text: str) -> None:
+    """Pretty printer used throughout the walkthrough."""
+    print(text)
+
+
+def main() -> None:
+    # Start from a clean slate so results are reproducible.
+    explain("==> Initializing blockchain…")
     if os.path.exists("chain_db"):
         shutil.rmtree("chain_db")
+
+    explain(f"Network chain ID: {the_block.chain_id_py()}")
     bc = the_block.Blockchain()
     bc.difficulty = 8
-    print(
-        "A fresh chain database is created. Difficulty determines how many leading zero bits a block hash must have."
+    explain(
+        "A fresh database is ready. Difficulty controls how many leading zero bits a block hash must have."
     )
-    print(f"Difficulty set to {bc.difficulty}\n")
+    explain(f"Difficulty set to {bc.difficulty}\n")
 
-    print("==> Adding accounts: 'miner' and 'alice'…")
+    explain("==> Adding accounts 'miner' and 'alice'…")
     bc.add_account("miner", 0, 0)
     bc.add_account("alice", 0, 0)
-    print(
-        "Accounts track two token balances: consumer and industrial. Both start at zero.\n"
-    )
+    explain("Accounts track two balances: consumer and industrial tokens.\n")
 
-    print("==> Generating ed25519 keypair for miner…")
+    explain("==> Generating ed25519 keypair for miner…")
     priv, pub = the_block.generate_keypair()
-    print(f"Private key length: {len(priv)}")
-    print(f"Public  key length: {len(pub)}\n")
+    explain(f"Private key bytes: {len(priv)}, public key bytes: {len(pub)}\n")
 
-    print("==> Signing & verifying a sample message…")
+    explain("==> Signing and verifying a sample message…")
     msg = b"test transaction"
     sig = the_block.sign_message(priv, msg)
-    assert the_block.verify_signature(pub, msg, sig), "Signature check failed"
-    print("Signature valid. These keys will be used to authorize real transfers.\n")
+    assert the_block.verify_signature(pub, msg, sig)
+    explain("Signature valid. These keys will be used to authorize transfers.\n")
 
-    print("==> Mining genesis block for 'miner'…")
+    explain("==> Mining genesis block for 'miner'…")
     block0 = bc.mine_block("miner")
-    print(f"Block {block0.index} mined, hash = {block0.hash}")
-    print("The genesis block gives the miner an initial reward so there is currency in circulation.")
+    assert bc.validate_block(block0)
+    explain(f"Block {block0.index} mined with hash {block0.hash}")
     m0 = bc.get_account_balance("miner")
     a0 = bc.get_account_balance("alice")
-    print(f"miner balance:    consumer={m0.consumer}, industrial={m0.industrial}")
-    print(f"alice balance:    consumer={a0.consumer}, industrial={a0.industrial}\n")
+    explain(f"miner balance: consumer={m0.consumer}, industrial={m0.industrial}")
+    explain(f"alice balance: consumer={a0.consumer}, industrial={a0.industrial}\n")
 
-    print(
-        "==> Submitting a real transaction: miner → alice (1 consumer, 2 industrial, fee=3)"
-    )
-    amt_cons, amt_ind, fee = 1, 2, 3
+    explain("==> Creating a real transaction: miner → alice")
     payload = the_block.RawTxPayload(
-        from_="miner", to="alice",
-        amount_consumer=amt_cons,
-        amount_industrial=amt_ind,
-        fee=fee,
+        from_="miner",
+        to="alice",
+        amount_consumer=1,
+        amount_industrial=2,
+        fee=3,
         fee_token=0,
         nonce=1,
         memo=b"",
     )
+    canonical = the_block.canonical_payload(payload)
+    explain(f"Canonical payload bytes: {canonical.hex()}")
     stx = the_block.sign_tx(list(priv), payload)
+    assert the_block.verify_signed_tx(stx)
     bc.submit_transaction(stx)
-    print(f"Transaction queued (fee={fee}).\n")
+    explain("Transaction queued.\n")
 
-    print(
-        "==> Mining next block for 'miner' (collecting fee)… This requires solving a proof-of-work puzzle."
-    )
+    explain("==> Mining next block and collecting the fee…")
     block1 = bc.mine_block("miner")
-    print(f"Block {block1.index} mined, hash = {block1.hash}")
+    assert bc.validate_block(block1)
+    explain(f"Block {block1.index} mined with hash {block1.hash}")
     m1 = bc.get_account_balance("miner")
     a1 = bc.get_account_balance("alice")
-    print(f"miner balance:    consumer={m1.consumer}, industrial={m1.industrial}")
-    print(f"alice balance:    consumer={a1.consumer}, industrial={a1.industrial}\n")
+    explain(f"miner balance: consumer={m1.consumer}, industrial={m1.industrial}")
+    explain(f"alice balance: consumer={a1.consumer}, industrial={a1.industrial}\n")
 
-    print("==> Emission & reward state:")
-    print(f" Block height:               {bc.block_height}")
-    print(f" Current block reward:       {bc.block_reward_consumer} (consumer), {bc.block_reward_industrial} (industrial)")
+    explain("==> Current emission and reward state")
+    explain(f" Block height:         {bc.block_height}")
+    explain(
+        f" Current block reward: {bc.block_reward_consumer} (consumer), {bc.block_reward_industrial} (industrial)"
+    )
     em_c, em_i = bc.circulating_supply()
-    print(f" Circulating supply:         {em_c} (consumer), {em_i} (industrial)\n")
+    explain(f" Circulating supply:   {em_c} (consumer), {em_i} (industrial)\n")
 
-    print("==> Mining 4 more blocks to demonstrate decay…")
-    print("Each block's reward shrinks slightly as part of the monetary policy.")
+    explain("==> Mining 4 more blocks to show reward decay…")
     for _ in range(4):
         blk = bc.mine_block("miner")
-        print(
-            f" Block {blk.index}: next reward = {bc.block_reward_consumer} (consumer)"
+        explain(
+            f" Block {blk.index} mined. Next reward will be {bc.block_reward_consumer} (consumer)"
         )
 
-    print("\n✅ All operations completed successfully.")
+    bc.persist_chain()
+    reopened = the_block.Blockchain.open("chain_db")
+    assert reopened.block_height == bc.block_height
+    explain(f"\nChain reopened at height {reopened.block_height}.")
+    explain("\n✅ Walkthrough completed successfully.")
+
 
 if __name__ == "__main__":
     main()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,11 @@ pub struct Block {
     pub coinbase_industrial: TokenAmount,
 }
 
+/// In-memory representation of the chain state and associated accounts.
+///
+/// `Blockchain` exposes high level methods for transaction submission,
+/// mining, and persistence. It backs the Python API used throughout the
+/// demo script and tests.
 #[pyclass]
 pub struct Blockchain {
     pub chain: Vec<Block>,
@@ -955,6 +960,10 @@ fn calculate_hash(
     hasher.finalize().to_hex().to_string()
 }
 
+/// Generate a new Ed25519 keypair.
+///
+/// Returns the private and public key as raw byte vectors. The keys are
+/// suitable for both transaction signing and simple message authentication.
 #[pyfunction]
 pub fn generate_keypair() -> (Vec<u8>, Vec<u8>) {
     let mut rng = OsRng;
@@ -965,6 +974,9 @@ pub fn generate_keypair() -> (Vec<u8>, Vec<u8>) {
     (priv_bytes.to_vec(), vk.to_bytes().to_vec())
 }
 
+/// Sign an arbitrary message with a 32-byte Ed25519 private key.
+///
+/// The returned signature is a 64-byte array in raw form.
 #[pyfunction]
 pub fn sign_message(private: Vec<u8>, message: Vec<u8>) -> PyResult<Vec<u8>> {
     let sk_bytes =
@@ -973,6 +985,7 @@ pub fn sign_message(private: Vec<u8>, message: Vec<u8>) -> PyResult<Vec<u8>> {
     Ok(sk.sign(&message).to_bytes().to_vec())
 }
 
+/// Verify a message signature produced by [`sign_message`].
 #[pyfunction]
 pub fn verify_signature(public: Vec<u8>, message: Vec<u8>, signature: Vec<u8>) -> bool {
     if let (Some(pk), Some(sig_bytes)) = (to_array_32(&public), to_array_64(&signature)) {
@@ -984,6 +997,7 @@ pub fn verify_signature(public: Vec<u8>, message: Vec<u8>, signature: Vec<u8>) -
     false
 }
 
+/// Return the integer network identifier used in domain separation.
 #[pyfunction]
 pub fn chain_id_py() -> u32 {
     CHAIN_ID

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -111,10 +111,12 @@ impl SignedTransaction {
     }
 }
 
+/// Serialize a [`RawTxPayload`] using the project's canonical bincode settings.
 pub fn canonical_payload_bytes(payload: &RawTxPayload) -> Vec<u8> {
     bincode_config().serialize(payload).unwrap()
 }
 
+/// Produce a signed transaction from raw bytes of a private key and payload.
 pub fn sign_tx(sk_bytes: &[u8], payload: &RawTxPayload) -> Option<SignedTransaction> {
     let sk_bytes = to_array_32(sk_bytes)?;
     let sk = SigningKey::from_bytes(&sk_bytes);
@@ -131,6 +133,7 @@ pub fn sign_tx(sk_bytes: &[u8], payload: &RawTxPayload) -> Option<SignedTransact
     })
 }
 
+/// Verify the Ed25519 signature inside a [`SignedTransaction`].
 pub fn verify_signed_tx(tx: &SignedTransaction) -> bool {
     if let (Some(pk), Some(sig_bytes)) = (to_array_32(&tx.public_key), to_array_64(&tx.signature)) {
         if let Ok(vk) = VerifyingKey::from_bytes(&pk) {
@@ -144,16 +147,19 @@ pub fn verify_signed_tx(tx: &SignedTransaction) -> bool {
 }
 
 #[pyfunction(name = "sign_tx")]
+/// Python wrapper for [`sign_tx`], raising ``ValueError`` on key size mismatch.
 pub fn sign_tx_py(sk_bytes: Vec<u8>, payload: RawTxPayload) -> PyResult<SignedTransaction> {
     sign_tx(&sk_bytes, &payload).ok_or_else(|| PyValueError::new_err("Invalid private key length"))
 }
 
 #[pyfunction(name = "verify_signed_tx")]
+/// Python wrapper for [`verify_signed_tx`]. Returns ``True`` on success.
 pub fn verify_signed_tx_py(tx: SignedTransaction) -> bool {
     verify_signed_tx(&tx)
 }
 
 #[pyfunction(name = "canonical_payload")]
+/// Python helper returning canonical bytes for a payload.
 pub fn canonical_payload_py(payload: RawTxPayload) -> Vec<u8> {
     canonical_payload_bytes(&payload)
 }


### PR DESCRIPTION
## Summary
- reinforce production-grade scope in README
- clarify demo intro text and printing helper
- assert chain height on reopen and tweak completion message
- document Python-facing transaction helpers

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all --release`
- `.venv/bin/python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a5d590124832ea7e660a97e67fd7e