### PR TITLE
refactor: simplify block mining API

### DIFF
--- a/tests/mempool_determinism.rs
+++ b/tests/mempool_determinism.rs
@@ -53,8 +53,8 @@ fn mempool_order_invariant() {
     chain_b.submit_transaction(tx2).unwrap();
     chain_b.submit_transaction(tx1).unwrap();
 
-    chain_a.mine_block("miner".into()).unwrap();
-    chain_b.mine_block("miner".into()).unwrap();
+    chain_a.mine_block("miner").unwrap();
+    chain_b.mine_block("miner").unwrap();
 
     assert_eq!(
         chain_a.chain.last().unwrap().hash,

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -74,7 +74,7 @@ proptest! {
         let miner = &miners[0];
         bc.add_account(miner.clone(), 0, 0).unwrap();
         bc.add_account(alice.clone(), 0, 0).unwrap();
-        bc.mine_block(miner.clone()).unwrap();
+        bc.mine_block(miner).unwrap();
         let (priv_bytes, _pub_bytes) = generate_keypair();
 
         for n in 0..tx_count {
@@ -82,10 +82,10 @@ proptest! {
             let _ = bc.submit_transaction(tx);
         }
 
-        bc.mine_block(miner.clone()).unwrap();
+        bc.mine_block(miner).unwrap();
 
-        let mb = bc.get_account_balance(miner.clone()).unwrap();
-        let ab = bc.get_account_balance(alice.clone()).unwrap();
+        let mb = bc.get_account_balance(miner).unwrap();
+        let ab = bc.get_account_balance(&alice).unwrap();
         assert!(mb.consumer as i128 >= 0 && ab.consumer as i128 >= 0);
         assert!(mb.industrial as i128 >= 0 && ab.industrial as i128 >= 0);
 
@@ -104,7 +104,7 @@ proptest! {
         {
             let mut w = bc.write().unwrap();
             w.add_account("miner".into(), 0, 0).unwrap();
-            w.mine_block("miner".into()).unwrap();
+            w.mine_block("miner").unwrap();
         }
         let (priv_bytes, _pub) = generate_keypair();
         let ops_vec = ops.clone();
@@ -129,10 +129,10 @@ proptest! {
                         let _ = bc
                             .write()
                             .unwrap()
-                            .drop_transaction("miner".into(), i as u64 + 1);
+                            .drop_transaction("miner", i as u64 + 1);
                     }
                     _ => {
-                        let _ = bc.write().unwrap().mine_block("miner".into());
+                        let _ = bc.write().unwrap().mine_block("miner");
                     }
                 }
             })
@@ -152,7 +152,7 @@ fn test_rejects_invalid_signature() {
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
     bc.add_account("alice".into(), 0, 0).unwrap();
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
 
     let (priv_bad, pub_bytes) = generate_keypair();
     let payload = RawTxPayload {
@@ -181,7 +181,7 @@ fn test_double_spend_is_rejected() {
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
     bc.add_account("alice".into(), 0, 0).unwrap();
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
 
     let (privkey, _pubk) = generate_keypair();
     let (amt_cons, amt_ind, fee) = (1_000_000_000_000_000, 1_000_000_000_000_000, 0);
@@ -197,10 +197,10 @@ fn test_block_reward_decays_and_emission_caps() {
     init();
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
     let mut last = bc.block_reward_consumer;
     for _ in 0..100 {
-        bc.mine_block("miner".into()).unwrap();
+        bc.mine_block("miner").unwrap();
         assert!(bc.block_reward_consumer <= last);
         last = bc.block_reward_consumer;
     }
@@ -208,7 +208,7 @@ fn test_block_reward_decays_and_emission_caps() {
     // simulate cap hit
     bc.emission_consumer = 20_000_000_000_000;
     bc.block_reward_consumer = TokenAmount::new(100);
-    let block = bc.mine_block("miner".into()).unwrap();
+    let block = bc.mine_block("miner").unwrap();
     assert_eq!(block.transactions[0].payload.amount_consumer, 0);
     let (em_cons, _) = bc.circulating_supply();
     assert!(em_cons <= 20_000_000_000_000);
@@ -220,7 +220,7 @@ fn test_coinbase_reward_recorded() {
     init();
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
-    let block = bc.mine_block("miner".into()).unwrap();
+    let block = bc.mine_block("miner").unwrap();
     let cb = &block.transactions[0];
     assert_eq!(block.coinbase_consumer.0, cb.payload.amount_consumer);
     assert_eq!(block.coinbase_industrial.0, cb.payload.amount_industrial);
@@ -233,16 +233,16 @@ fn test_fee_credit_to_miner() {
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
     bc.add_account("alice".into(), 0, 0).unwrap();
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
 
     let (privkey, _pubk) = generate_keypair();
     let fee = 7;
     let tx = testutil::build_signed_tx(&privkey, "miner", "alice", 1, 2, fee, 1);
 
     bc.submit_transaction(tx).unwrap();
-    let before = bc.get_account_balance("miner".into()).unwrap();
-    bc.mine_block("miner".into()).unwrap();
-    let after = bc.get_account_balance("miner".into()).unwrap();
+    let before = bc.get_account_balance("miner").unwrap();
+    bc.mine_block("miner").unwrap();
+    let after = bc.get_account_balance("miner").unwrap();
 
     assert!(after.consumer >= before.consumer + fee);
 }
@@ -255,7 +255,7 @@ fn test_replay_attack_prevention() {
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
     bc.add_account("alice".into(), 0, 0).unwrap();
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
 
     let (privkey, _pubk) = generate_keypair();
     let tx = testutil::build_signed_tx(&privkey, "miner", "alice", 5, 2, 0, 1);
@@ -273,7 +273,7 @@ fn test_mempool_flush_on_block_mine() {
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
     bc.add_account("alice".into(), 0, 0).unwrap();
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
 
     let (privkey, _pubk) = generate_keypair();
     for n in 0..100 {
@@ -281,7 +281,7 @@ fn test_mempool_flush_on_block_mine() {
         let _ = bc.submit_transaction(tx);
     }
     assert!(!bc.mempool.is_empty());
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
     assert!(bc.mempool.is_empty());
 }
 
@@ -292,12 +292,12 @@ fn test_duplicate_txid_rejected() {
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
     bc.add_account("alice".into(), 0, 0).unwrap();
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
 
     let (privkey, _pub) = generate_keypair();
     let tx1 = testutil::build_signed_tx(&privkey, "miner", "alice", 1, 0, 0, 1);
     bc.submit_transaction(tx1.clone()).unwrap();
-    let block = bc.mine_block("miner".into()).unwrap();
+    let block = bc.mine_block("miner").unwrap();
 
     let mut bad_block = block.clone();
     bad_block.transactions.push(tx1);
@@ -311,12 +311,12 @@ fn test_duplicate_sender_nonce_rejected_in_block() {
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
     bc.add_account("alice".into(), 0, 0).unwrap();
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
 
     let (privkey, _pub) = generate_keypair();
     let tx1 = testutil::build_signed_tx(&privkey, "miner", "alice", 1, 0, 0, 1);
     bc.submit_transaction(tx1.clone()).unwrap();
-    let block = bc.mine_block("miner".into()).unwrap();
+    let block = bc.mine_block("miner").unwrap();
 
     let mut bad_block = block.clone();
     let tx2 = testutil::build_signed_tx(&privkey, "miner", "alice", 2, 0, 0, 1);
@@ -331,7 +331,7 @@ fn test_pending_nonce_and_balances() {
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
     bc.add_account("alice".into(), 0, 0).unwrap();
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
 
     let (privkey, _pub) = generate_keypair();
     // first tx with nonce 1
@@ -353,7 +353,7 @@ fn test_pending_nonce_and_balances() {
     let huge = testutil::build_signed_tx(&privkey, "miner", "alice", u64::MAX / 2, 0, 0, 3);
     assert!(bc.submit_transaction(huge).is_err());
 
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
     let sender = bc.accounts.get("miner").unwrap();
     assert_eq!(sender.pending_nonce, 0);
     assert_eq!(sender.pending_consumer, 0);
@@ -371,7 +371,7 @@ fn test_drop_transaction_releases_pending() {
     let tx = testutil::build_signed_tx(&privkey, "miner", "alice", 1, 1, 1, 1);
     bc.submit_transaction(tx).unwrap();
     assert_eq!(bc.accounts.get("miner").unwrap().pending_nonce, 1);
-    bc.drop_transaction("miner".into(), 1).unwrap();
+    bc.drop_transaction("miner", 1).unwrap();
     let sender = bc.accounts.get("miner").unwrap();
     assert_eq!(sender.pending_nonce, 0);
     assert_eq!(sender.pending_consumer, 0);
@@ -386,11 +386,11 @@ fn test_fee_checksum_enforced() {
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
     bc.add_account("alice".into(), 0, 0).unwrap();
-    bc.mine_block("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
     let (privkey, _pub) = generate_keypair();
     let tx = testutil::build_signed_tx(&privkey, "miner", "alice", 1, 0, 2, 1);
     bc.submit_transaction(tx).unwrap();
-    let mut block = bc.mine_block("miner".into()).unwrap();
+    let mut block = bc.mine_block("miner").unwrap();
     assert!(bc.validate_block(&block).unwrap());
     block.fee_checksum = "00".repeat(32);
     assert!(!bc.validate_block(&block).unwrap());
@@ -405,7 +405,7 @@ fn test_multithreaded_submit_and_mine() {
         let mut chain = write_lock!(bc);
         chain.add_account("miner".into(), 0, 0).unwrap();
         chain.add_account("bob".into(), 0, 0).unwrap();
-        chain.mine_block("miner".into()).unwrap();
+        chain.mine_block("miner").unwrap();
     }
     let (privkey, _pubk) = generate_keypair();
 
@@ -418,7 +418,7 @@ fn test_multithreaded_submit_and_mine() {
                     let tx = testutil::build_signed_tx(&privkey, "miner", "bob", 1, 1, 0, n + 1);
                     let mut chain = write_lock!(bc);
                     let _ = chain.submit_transaction(tx.clone());
-                    let _ = chain.mine_block("miner".into());
+                    let _ = chain.mine_block("miner");
                 }
             })
         })
@@ -428,8 +428,8 @@ fn test_multithreaded_submit_and_mine() {
         h.join().unwrap();
     }
 
-    let miner = read_lock!(bc).get_account_balance("miner".into()).unwrap();
-    let bob = read_lock!(bc).get_account_balance("bob".into()).unwrap();
+    let miner = read_lock!(bc).get_account_balance("miner").unwrap();
+    let bob = read_lock!(bc).get_account_balance("bob").unwrap();
     assert!(miner.consumer as i128 >= 0 && bob.consumer as i128 >= 0);
 }
 
@@ -439,7 +439,7 @@ fn test_rejects_corrupt_block() {
     init();
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
-    let mut block = bc.mine_block("miner".into()).unwrap();
+    let mut block = bc.mine_block("miner").unwrap();
     block.hash = "deadbeef".repeat(8);
     assert!(!bc.validate_block(&block).unwrap());
 }
@@ -450,12 +450,12 @@ fn test_chain_persistence() {
     init();
     let mut bc = Blockchain::new();
     bc.add_account("miner".into(), 0, 0).unwrap();
-    bc.mine_block("miner".into()).unwrap();
-    let before = bc.get_account_balance("miner".into()).unwrap();
+    bc.mine_block("miner").unwrap();
+    let before = bc.get_account_balance("miner").unwrap();
     drop(bc);
 
     let bc2 = Blockchain::new();
-    if let Ok(after) = bc2.get_account_balance("miner".into()) {
+    if let Ok(after) = bc2.get_account_balance("miner") {
         assert_eq!(before.consumer, after.consumer);
     }
 }
@@ -469,15 +469,15 @@ fn test_fork_and_reorg_resolution() {
 
     for bc in [&mut bc1, &mut bc2].iter_mut() {
         bc.add_account("miner".into(), 0, 0).unwrap();
-        bc.mine_block("miner".into()).unwrap();
+        bc.mine_block("miner").unwrap();
     }
 
     // chain lengths diverge
     for _ in 0..5 {
-        bc1.mine_block("miner".into()).unwrap();
+        bc1.mine_block("miner").unwrap();
     }
     for _ in 0..10 {
-        bc2.mine_block("miner".into()).unwrap();
+        bc2.mine_block("miner").unwrap();
     }
 
     // import longer into shorter
@@ -486,8 +486,8 @@ fn test_fork_and_reorg_resolution() {
 
     assert_eq!(bc1.chain, bc2.chain);
     assert_eq!(
-        bc1.get_account_balance("miner".into()).unwrap().consumer,
-        bc2.get_account_balance("miner".into()).unwrap().consumer
+        bc1.get_account_balance("miner").unwrap().consumer,
+        bc2.get_account_balance("miner").unwrap().consumer
     );
 }
 
@@ -499,13 +499,13 @@ fn test_import_reward_mismatch() {
     let mut bc2 = Blockchain::new();
     for bc in [&mut bc1, &mut bc2].iter_mut() {
         bc.add_account("miner".into(), 0, 0).unwrap();
-        bc.mine_block("miner".into()).unwrap();
+        bc.mine_block("miner").unwrap();
     }
     for _ in 0..3 {
-        bc1.mine_block("miner".into()).unwrap();
+        bc1.mine_block("miner").unwrap();
     }
     for _ in 0..6 {
-        bc2.mine_block("miner".into()).unwrap();
+        bc2.mine_block("miner").unwrap();
     }
     let mut fork = bc2.chain.clone();
     let idx = fork.len() - 3;
@@ -521,7 +521,7 @@ fn test_fuzz_unicode_and_overflow_addresses() {
     let mut bc = Blockchain::new();
     let crazy = "矿工💎🚀𠜎𠜱𡃁𡈽".to_string();
     bc.add_account(crazy.clone(), u64::MAX, u64::MAX).unwrap();
-    let bal = bc.get_account_balance(crazy).unwrap();
+    let bal = bc.get_account_balance(&crazy).unwrap();
     assert_eq!(bal.consumer, u64::MAX);
     assert_eq!(bal.industrial, u64::MAX);
 }
@@ -534,7 +534,7 @@ fn test_chain_determinism() {
     let mut bc2 = Blockchain::new();
     for bc in [&mut bc1, &mut bc2].iter_mut() {
         bc.add_account("miner".into(), 0, 0).unwrap();
-        bc.mine_block("miner".into()).unwrap();
+        bc.mine_block("miner").unwrap();
     }
 
     let (privkey, _pubk) = generate_keypair();
@@ -543,9 +543,8 @@ fn test_chain_determinism() {
     bc1.submit_transaction(tx1).unwrap();
     bc2.submit_transaction(tx2).unwrap();
 
-    bc1.mine_block("miner".into()).unwrap();
-    bc2.mine_block("miner".into()).unwrap();
+    bc1.mine_block("miner").unwrap();
+    bc2.mine_block("miner").unwrap();
 
     assert_eq!(bc1.chain, bc2.chain);
 }
-


### PR DESCRIPTION
## Summary
- mark chain length accessor as must-use
- accept `&str` miner address and document mining behavior
- borrow account identifiers and document account APIs
- adjust tests for updated mining and account APIs

## Testing
- `cargo test --all --release`
- `maturin develop --release`
- `.venv/bin/python -m pytest`
- `.venv/bin/python demo.py`
- `cargo clippy --all-targets -- -D warnings` *(fails: numerous pedantic lint errors)*
- `cargo-deny check advisories -c temp-deny.toml --disable-fetch` *(fails: missing local advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68901d204170832ebf67df86cea0c2c9