### PR TITLE
mempool: guard mining with global lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,23 @@
 - Breaking: database schema **v4** adds per-account mempool caps and TTL
   indexes; `Blockchain::open` rebuilds the mempool on startup dropping
   expired or orphaned entries.
+- Breaking: mempool entries persist `timestamp_millis`; schema v4 serializes
+  pending transactions and enforces TTL on restart.
 - Fix: isolate temporary chain directories for tests and enable replay attack
   prevention to reject duplicate `(sender, nonce)` pairs.
 - Fix: enforce mempool capacity via atomic counter and `O(log n)` priority
   heap; timestamps stored as monotonic ticks.
+- Fix: guard mining mempool mutations with global mutex to enforce
+  capacity under concurrency.
 - Feat: introduce minimum fee-per-byte floor with `FeeTooLow` rejection.
 - Feat: expose mempool limits (`max_mempool_size`, `min_fee_per_byte`,
   `tx_ttl`, `max_pending_per_account`) via `TB_*` env vars and sweep expired
   entries on startup.
+- Feat: add Prometheus metrics for TTL drops (`ttl_drop_total`) and
+  lock poisoning (`lock_poison_total`).
+- Feat: orphan sweeps rebuild heap when `orphan_counter > mempool_size / 2` and
+  reset the counter; panic-inject test covers global mempool mutex.
+- Test: add panic-inject harness covering drop path lock poisoning and recovery.
 
 ### CLI Flags
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -4,14 +4,20 @@ use prometheus::{Encoder, IntCounter, IntGauge, Registry, TextEncoder};
 pub static REGISTRY: Lazy<Registry> = Lazy::new(Registry::new);
 
 pub static MEMPOOL_SIZE: Lazy<IntGauge> = Lazy::new(|| {
-    let g = IntGauge::new("mempool_size", "Current mempool size").unwrap();
-    REGISTRY.register(Box::new(g.clone())).unwrap();
+    let g = IntGauge::new("mempool_size", "Current mempool size")
+        .unwrap_or_else(|e| panic!("gauge: {e}"));
+    REGISTRY
+        .register(Box::new(g.clone()))
+        .unwrap_or_else(|e| panic!("registry: {e}"));
     g
 });
 
 pub static EVICTIONS_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
-    let c = IntCounter::new("evictions_total", "Total mempool evictions").unwrap();
-    REGISTRY.register(Box::new(c.clone())).unwrap();
+    let c = IntCounter::new("evictions_total", "Total mempool evictions")
+        .unwrap_or_else(|e| panic!("counter: {e}"));
+    REGISTRY
+        .register(Box::new(c.clone()))
+        .unwrap_or_else(|e| panic!("registry: {e}"));
     c
 });
 
@@ -20,26 +26,73 @@ pub static FEE_FLOOR_REJECT_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
         "fee_floor_reject_total",
         "Transactions rejected for low fee",
     )
-    .unwrap();
-    REGISTRY.register(Box::new(c.clone())).unwrap();
+    .unwrap_or_else(|e| panic!("counter: {e}"));
+    REGISTRY
+        .register(Box::new(c.clone()))
+        .unwrap_or_else(|e| panic!("registry: {e}"));
     c
 });
 
 pub static DUP_TX_REJECT_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
-    let c = IntCounter::new("dup_tx_reject_total", "Transactions rejected as duplicate").unwrap();
-    REGISTRY.register(Box::new(c.clone())).unwrap();
+    let c = IntCounter::new("dup_tx_reject_total", "Transactions rejected as duplicate")
+        .unwrap_or_else(|e| panic!("counter: {e}"));
+    REGISTRY
+        .register(Box::new(c.clone()))
+        .unwrap_or_else(|e| panic!("registry: {e}"));
     c
 });
 
 pub static TX_ADMITTED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
-    let c = IntCounter::new("tx_admitted_total", "Total admitted transactions").unwrap();
-    REGISTRY.register(Box::new(c.clone())).unwrap();
+    let c = IntCounter::new("tx_admitted_total", "Total admitted transactions")
+        .unwrap_or_else(|e| panic!("counter: {e}"));
+    REGISTRY
+        .register(Box::new(c.clone()))
+        .unwrap_or_else(|e| panic!("registry: {e}"));
     c
 });
 
 pub static TX_REJECTED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
-    let c = IntCounter::new("tx_rejected_total", "Total rejected transactions").unwrap();
-    REGISTRY.register(Box::new(c.clone())).unwrap();
+    let c = IntCounter::new("tx_rejected_total", "Total rejected transactions")
+        .unwrap_or_else(|e| panic!("counter: {e}"));
+    REGISTRY
+        .register(Box::new(c.clone()))
+        .unwrap_or_else(|e| panic!("registry: {e}"));
+    c
+});
+
+pub static TTL_DROP_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    let c = IntCounter::new(
+        "ttl_drop_total",
+        "Transactions dropped due to TTL expiration",
+    )
+    .unwrap_or_else(|e| panic!("counter: {e}"));
+    REGISTRY
+        .register(Box::new(c.clone()))
+        .unwrap_or_else(|e| panic!("registry: {e}"));
+    c
+});
+
+pub static LOCK_POISON_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    let c = IntCounter::new(
+        "lock_poison_total",
+        "Lock acquisition failures due to poisoning",
+    )
+    .unwrap_or_else(|e| panic!("counter: {e}"));
+    REGISTRY
+        .register(Box::new(c.clone()))
+        .unwrap_or_else(|e| panic!("registry: {e}"));
+    c
+});
+
+pub static ORPHAN_SWEEP_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    let c = IntCounter::new(
+        "orphan_sweep_total",
+        "Transactions dropped because the sender account is missing",
+    )
+    .unwrap_or_else(|e| panic!("counter: {e}"));
+    REGISTRY
+        .register(Box::new(c.clone()))
+        .unwrap_or_else(|e| panic!("registry: {e}"));
     c
 });
 
@@ -47,6 +100,8 @@ pub fn gather() -> String {
     let mut buffer = Vec::new();
     let encoder = TextEncoder::new();
     let metrics = REGISTRY.gather();
-    encoder.encode(&metrics, &mut buffer).unwrap();
+    encoder
+        .encode(&metrics, &mut buffer)
+        .unwrap_or_else(|e| panic!("encode: {e}"));
     String::from_utf8(buffer).unwrap_or_default()
 }

--- a/tests/admission.rs
+++ b/tests/admission.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Instant;
+use std::time::{SystemTime, UNIX_EPOCH};
 use the_block::hashlayout::BlockEncoder;
 use the_block::{
     generate_keypair, sign_tx, Blockchain, MempoolEntry, RawTxPayload, SignedTransaction,
@@ -63,7 +63,10 @@ fn mine_block_skips_nonce_gaps() {
         ("miner".into(), 5),
         MempoolEntry {
             tx: tx.clone(),
-            timestamp: Instant::now(),
+            timestamp_millis: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
         },
     );
     let block = bc.mine_block("miner").unwrap();


### PR DESCRIPTION
## Summary
- ensure mining removes transactions under global mempool mutex and per-sender locks
- add 64-thread cap-race test and document global mempool lock
- add regression test ensuring chain import rejects blocks with incorrect difficulty
- track TTL expirations and lock poisoning with new Prometheus metrics and docs
- drop orphaned mempool entries during sweeps and expose `orphan_sweep_total`
- add panic-inject harness covering drop path lock poisoning and recovery
- persist mempool entries with timestamp_millis and rebuild heap when orphan ratio exceeds half of mempool
- expose global mempool lock panic harness and TTL-expiry restart test

## Testing
- `cargo test --tests --features telemetry`
- `cargo clippy --all-targets --features telemetry`

------
https://chatgpt.com/codex/tasks/task_e_68949f2a6810832eb7a2a939486852d3