### PR TITLE
doc: fix startup purge metrics and anchors

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Telemetry
 - `TTL_DROP_TOTAL` counts transactions purged due to TTL expiry.
+- `STARTUP_TTL_DROP_TOTAL` reports expired mempool entries dropped during
+  startup rebuild.
 - `ORPHAN_SWEEP_TOTAL` tracks heap rebuilds triggered by orphan ratios.
 - `LOCK_POISON_TOTAL` records mutex poisoning events.
 - `INVALID_SELECTOR_REJECT_TOTAL`, `BALANCE_OVERFLOW_REJECT_TOTAL`, and
@@ -20,9 +22,13 @@
 - `serve_metrics(addr)` exposes Prometheus text over a lightweight HTTP listener.
 - Spans `mempool_mutex`, `admission_lock`, `eviction_sweep`, and
   `startup_rebuild` record sender, nonce, fee-per-byte, and mempool size
-  ([src/lib.rs](src/lib.rs#L1053-L1068),
-  [src/lib.rs](src/lib.rs#L1522-L1528),
-  [src/lib.rs](src/lib.rs#L1603-L1637)).
+  ([src/lib.rs](src/lib.rs#L1066-L1081),
+  [src/lib.rs](src/lib.rs#L1535-L1541),
+  [src/lib.rs](src/lib.rs#L1621-L1656),
+  [src/lib.rs](src/lib.rs#L878-L888)).
 - Documented `mempool_mutex → sender_mutex` lock order and added
   `admit_and_mine_never_over_cap` regression to prove the mempool size
-  invariant and startup TTL purges during `Blockchain::open`.
+  invariant.
+- **B ‑5 Startup TTL Purge — COMPLETED** – `Blockchain::open` now invokes [`purge_expired`](src/lib.rs#L1596-L1665)
+  ([src/lib.rs](src/lib.rs#L917-L934)), recording
+  `ttl_drop_total`, `startup_ttl_drop_total`, and `expired_drop_total` on restart.

--- a/Agent-Next-Instructions.md
+++ b/Agent-Next-Instructions.md
@@ -21,14 +21,15 @@ re‑implement:
    directories and `test_replay_attack_prevention` enforces `(sender, nonce)`
    dedup.
 5. **Telemetry expansion**: HTTP metrics exporter, `ttl_drop_total`,
-   `lock_poison_total`, `orphan_sweep_total`,
+   `startup_ttl_drop_total` (expired mempool entries dropped during startup), `lock_poison_total`, `orphan_sweep_total`,
    `invalid_selector_reject_total`, `balance_overflow_reject_total`,
    `drop_not_found_total`, `tx_rejected_total{reason=*}`, and span coverage
    for `mempool_mutex`, `admission_lock`, `eviction_sweep`, and
    `startup_rebuild` capturing sender, nonce, fee_per_byte, and
-   mempool_size ([`src/lib.rs`](src/lib.rs#L1053-L1068),
-   [`src/lib.rs`](src/lib.rs#L1522-L1528),
-  [`src/lib.rs`](src/lib.rs#L1603-L1637)). Comparator ordering test for
+  mempool_size ([`src/lib.rs`](src/lib.rs#L1066-L1081),
+    [`src/lib.rs`](src/lib.rs#L1535-L1541),
+    [`src/lib.rs`](src/lib.rs#L1621-L1656),
+    [`src/lib.rs`](src/lib.rs#L878-L888)). Comparator ordering test for
    mempool priority.
 6. **Mempool atomicity**: global `mempool_mutex → sender_mutex` critical section with
    counter updates, heap ops, and pending balances inside; orphan sweeps rebuild
@@ -36,6 +37,10 @@ re‑implement:
 7. **Timestamp persistence & eviction proof**: mempool entries persist
    `timestamp_ticks` for deterministic startup purge; panic-inject eviction test
    proves lock-poison recovery.
+8. **B‑5 Startup TTL Purge — COMPLETED**: `Blockchain::open` batches mempool rebuilds,
+   invokes [`purge_expired`](src/lib.rs#L1596-L1665) on startup
+   ([src/lib.rs](src/lib.rs#L917-L934)), and restart tests ensure both
+   `ttl_drop_total` and `startup_ttl_drop_total` advance.
 
 ---
 
@@ -82,15 +87,16 @@ Treat the following as blockers. Implement each with atomic commits, exhaustive 
    - `ttl_expired_purged_on_restart` exercises TTL expiry across restarts.
    - `test_schema_upgrade_compatibility` verifies v1/v2/v3 → v4 migration.
 2. **Telemetry & Logging Expansion**
-   - Add counters `TTL_DROP_TOTAL`, `ORPHAN_SWEEP_TOTAL`, `LOCK_POISON_TOTAL`,
-     `INVALID_SELECTOR_REJECT_TOTAL`, `BALANCE_OVERFLOW_REJECT_TOTAL`,
+   - Add counters `TTL_DROP_TOTAL`, `STARTUP_TTL_DROP_TOTAL`, `ORPHAN_SWEEP_TOTAL`,
+     `LOCK_POISON_TOTAL`, `INVALID_SELECTOR_REJECT_TOTAL`, `BALANCE_OVERFLOW_REJECT_TOTAL`,
      `DROP_NOT_FOUND_TOTAL`, plus global `TX_REJECTED_TOTAL{reason=*}` with
      regression tests for each labelled rejection.
    - Instrument spans `mempool_mutex`, `admission_lock`, `eviction_sweep`,
      and `startup_rebuild` capturing sender, nonce, fee_per_byte,
-     mempool_size ([`src/lib.rs`](src/lib.rs#L1053-L1068),
-     [`src/lib.rs`](src/lib.rs#L1522-L1528),
-     [`src/lib.rs`](src/lib.rs#L1603-L1637)).
+     mempool_size ([`src/lib.rs`](src/lib.rs#L1066-L1081),
+     [`src/lib.rs`](src/lib.rs#L1535-L1541),
+     [`src/lib.rs`](src/lib.rs#L1621-L1656),
+     [`src/lib.rs`](src/lib.rs#L878-L888)).
    - Document scrape example for `serve_metrics` and span list in
      `docs/detailed_updates.md` and specs.
 3. **Test & Fuzz Matrix**

--- a/CONSENSUS.md
+++ b/CONSENSUS.md
@@ -71,7 +71,7 @@ The `GENESIS_HASH` constant is asserted at compile time against the hash derived
 `Blockchain::mempool` is backed by a `DashMap` keyed by `(sender, nonce)` with
 mutations guarded by a global `mempool_mutex`.
 A tracing span captures each admission at this lock boundary
-([src/lib.rs](src/lib.rs#L1053-L1068)).
+([src/lib.rs](src/lib.rs#L1066-L1081)).
 A binary heap ordered by `(fee_per_byte DESC, expires_at ASC, tx_hash ASC)`
 provides `O(log n)` eviction. Example ordering:
 
@@ -90,25 +90,35 @@ updates, heap pushes/pops, and pending balance/nonces occur within this order,
 guaranteeing `mempool_size ≤ max_mempool_size`. Each sender is
 limited to 16 pending transactions. Entries expire after `tx_ttl` seconds
 (default 1800) based on the persisted admission timestamp and are purged on new
-submissions and at startup, logging `expired_drop_total`. In schema v4 each
-mempool record serializes `[sender, nonce, tx, timestamp_millis, timestamp_ticks]`
-where `timestamp_ticks` is a monotonic counter used for deterministic tie
-breaking. `Blockchain::open` rebuilds the heap from this list, dropping any entry
-whose TTL has elapsed or whose sender account is missing and restoring
-`mempool_size` from the survivors ([src/lib.rs](src/lib.rs#L865-L894)).
-Transactions whose sender account has been
-removed are counted in an `orphan_counter`. TTL purges and explicit drops
-decrement this counter. When `orphan_counter > mempool_size / 2` (orphans exceed
-half of the pool) a sweep rebuilds the heap, drops all orphans, emits
-`ORPHAN_SWEEP_TOTAL`, and resets the counter
-([src/lib.rs](src/lib.rs#L1585-L1645)).
+submissions and at startup via `purge_expired()`, logging `expired_drop_total`
+and advancing `ttl_drop_total`. In schema v4 each mempool record serializes
+`[sender, nonce, tx, timestamp_millis, timestamp_ticks]` where `timestamp_ticks`
+is a monotonic counter used for deterministic tie breaking. `Blockchain::open`
+rebuilds the heap from this list, skips entries whose sender account is missing,
+invokes `purge_expired` to drop any whose TTL has elapsed, and restores
+`mempool_size` from the survivors ([src/lib.rs](src/lib.rs#L854-L915)).
+Transactions whose sender account has been removed are counted in an
+`orphan_counter`. TTL purges and explicit drops decrement this counter. When
+`orphan_counter > mempool_size / 2` (orphans exceed half of the pool) a sweep
+rebuilds the heap, drops all orphans, emits `ORPHAN_SWEEP_TOTAL`, and resets the
+counter ([src/lib.rs](src/lib.rs#L1637-L1662)).
+
+### Startup Rebuild & TTL Purge
+
+On restart `Blockchain::open` rehydrates mempool entries from disk, incrementing
+`mempool_size` for each inserted record and counting missing-account entries.
+After hydration it calls [`purge_expired`](src/lib.rs#L1596-L1665) to drop
+TTL-expired entries, update [`orphan_counter`](src/lib.rs#L1637-L1662), and
+return the number removed. The sum of these drops is reported as
+`expired_drop_total`; `TTL_DROP_TOTAL` and `STARTUP_TTL_DROP_TOTAL` advance for visibility as entries load in 256-entry batches
+([src/lib.rs](src/lib.rs#L917-L934)).
 
 Transactions from unknown senders are rejected. Nodes must provision accounts via
 `add_account` before submitting any transaction.
 
 Telemetry counters exported: `mempool_size`, `evictions_total`,
 `fee_floor_reject_total`, `dup_tx_reject_total`, `ttl_drop_total`,
-`lock_poison_total`, `orphan_sweep_total`,
+`startup_ttl_drop_total` (expired mempool entries dropped during startup), `lock_poison_total`, `orphan_sweep_total`,
 `invalid_selector_reject_total`, `balance_overflow_reject_total`,
 `drop_not_found_total`, `tx_rejected_total{reason=*}`. `serve_metrics(addr)`
 exposes these metrics over HTTP; e.g. `curl -s localhost:9000/metrics | grep

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +106,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +131,58 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "const-oid"
@@ -119,6 +204,73 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -215,6 +367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +434,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +454,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -300,10 +474,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -383,6 +587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +629,34 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -639,12 +877,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -676,6 +957,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +979,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -822,6 +1118,7 @@ dependencies = [
  "base64",
  "bincode",
  "blake3",
+ "criterion",
  "dashmap",
  "ed25519-dalek",
  "hex",
@@ -858,6 +1155,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -937,6 +1244,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +1266,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,11 @@ features = ["pyo3/extension-module"]
 logtest = "2"
 base64 = "0.22"
 proptest = "1"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "startup_rebuild"
+harness = false
 
 [build-dependencies]
 blake3 = "1"

--- a/benches/startup_rebuild.rs
+++ b/benches/startup_rebuild.rs
@@ -1,0 +1,102 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::time::{SystemTime, UNIX_EPOCH};
+use the_block::{
+    sign_tx, Account, Blockchain, MempoolEntry, MempoolEntryDisk, Pending, RawTxPayload,
+    TokenBalance, STARTUP_REBUILD_BATCH,
+};
+
+fn sample_entries(count: usize) -> (Vec<MempoolEntryDisk>, Account) {
+    let (sk, _pk) = the_block::generate_keypair();
+    let mut entries = Vec::with_capacity(count);
+    for i in 0..count {
+        let payload = RawTxPayload {
+            from_: "a".into(),
+            to: "b".into(),
+            amount_consumer: 1,
+            amount_industrial: 0,
+            fee: 1,
+            fee_selector: 0,
+            nonce: i as u64,
+            memo: Vec::new(),
+        };
+        let tx = sign_tx(sk.to_vec(), payload).unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        entries.push(MempoolEntryDisk {
+            sender: "a".into(),
+            nonce: i as u64,
+            tx,
+            timestamp_millis: now,
+            timestamp_ticks: i as u64,
+        });
+    }
+    let account = Account {
+        address: "a".into(),
+        balance: TokenBalance {
+            consumer: 1_000_000,
+            industrial: 1_000_000,
+        },
+        nonce: 0,
+        pending: Pending::default(),
+    };
+    (entries, account)
+}
+
+fn rebuild_naive(entries: &[MempoolEntryDisk], acc: &Account) {
+    let mut bc = Blockchain::default();
+    bc.accounts.insert(acc.address.clone(), acc.clone());
+    for e in entries.iter() {
+        bc.mempool.insert(
+            (e.sender.clone(), e.nonce),
+            MempoolEntry {
+                tx: e.tx.clone(),
+                timestamp_millis: e.timestamp_millis,
+                timestamp_ticks: e.timestamp_ticks,
+            },
+        );
+    }
+}
+
+fn rebuild_batched(entries: &[MempoolEntryDisk], acc: &Account) {
+    let mut bc = Blockchain::default();
+    bc.accounts.insert(acc.address.clone(), acc.clone());
+    let mut iter = entries.iter();
+    loop {
+        let mut batch = Vec::with_capacity(STARTUP_REBUILD_BATCH);
+        for _ in 0..STARTUP_REBUILD_BATCH {
+            if let Some(e) = iter.next() {
+                batch.push(e);
+            } else {
+                break;
+            }
+        }
+        if batch.is_empty() {
+            break;
+        }
+        for e in batch {
+            bc.mempool.insert(
+                (e.sender.clone(), e.nonce),
+                MempoolEntry {
+                    tx: e.tx.clone(),
+                    timestamp_millis: e.timestamp_millis,
+                    timestamp_ticks: e.timestamp_ticks,
+                },
+            );
+        }
+    }
+}
+
+fn bench_startup_rebuild(c: &mut Criterion) {
+    let (entries, account) = sample_entries(1_000);
+    c.bench_function("rebuild_naive", |b| {
+        b.iter(|| rebuild_naive(&entries, &account))
+    });
+    c.bench_function("rebuild_batched", |b| {
+        b.iter(|| rebuild_batched(&entries, &account))
+    });
+}
+
+criterion_group!(benches, bench_startup_rebuild);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,7 @@ use thiserror::Error;
 #[cfg(feature = "telemetry")]
 pub mod telemetry;
 #[cfg(feature = "telemetry")]
-pub use telemetry::gather as gather_metrics;
-#[cfg(feature = "telemetry")]
-pub use telemetry::serve as serve_metrics;
+pub use telemetry::{gather_metrics, serve_metrics};
 
 pub mod blockchain;
 use blockchain::difficulty;
@@ -150,6 +148,10 @@ const INITIAL_BLOCK_REWARD_CONSUMER: u64 = 60_000;
 const INITIAL_BLOCK_REWARD_INDUSTRIAL: u64 = 30_000;
 const DECAY_NUMERATOR: u64 = 99995; // ~0.005% per block
 const DECAY_DENOMINATOR: u64 = 100_000;
+
+// === Startup rebuild tuning ===
+/// Number of mempool entries processed per batch during `Blockchain::open`.
+pub const STARTUP_REBUILD_BATCH: usize = 256;
 
 // === Helpers for Ed25519 v2.x ([u8;32], [u8;64]) ===
 /// Converts a byte slice into a fixed 32-byte array, returning `None` on length
@@ -847,65 +849,71 @@ impl Blockchain {
             }
         }
 
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_else(|e| panic!("time: {e}"))
-            .as_millis() as u64;
-        let ttl_ms = bc.tx_ttl * 1000;
-        let mut expired_drop_total = 0u64;
-        for e in mempool_disk {
-            let size = bincode::serialize(&e.tx)
-                .map(|b| b.len() as u64)
-                .unwrap_or(0);
-            let fpb = if size == 0 {
-                0
-            } else {
-                e.tx.payload.fee / size
-            };
-            #[cfg(feature = "telemetry")]
-            let _span = tracing::span!(
-                tracing::Level::TRACE,
-                "startup_rebuild",
-                sender = %e.sender,
-                nonce = e.nonce,
-                fpb,
-                mempool_size = bc
-                    .mempool_size
-                    .load(std::sync::atomic::Ordering::SeqCst)
-            )
-            .entered();
-            #[cfg(not(feature = "telemetry"))]
-            let _ = fpb;
-            if bc.accounts.contains_key(&e.sender) {
-                if now.saturating_sub(e.timestamp_millis) > ttl_ms {
-                    #[cfg(feature = "telemetry")]
-                    telemetry::TTL_DROP_TOTAL.inc();
-                    expired_drop_total += 1;
-                    continue;
+        let mut missing_drop_total = 0u64;
+        let mut iter = mempool_disk.into_iter();
+        loop {
+            let mut batch = Vec::with_capacity(STARTUP_REBUILD_BATCH);
+            for _ in 0..STARTUP_REBUILD_BATCH {
+                if let Some(e) = iter.next() {
+                    batch.push(e);
+                } else {
+                    break;
                 }
-                bc.mempool.insert(
-                    (e.sender.clone(), e.nonce),
-                    MempoolEntry {
-                        tx: e.tx.clone(),
-                        timestamp_millis: e.timestamp_millis,
-                        timestamp_ticks: e.timestamp_ticks,
-                    },
-                );
-                bc.inc_mempool_size();
-                if let Some(acc) = bc.accounts.get_mut(&e.sender) {
-                    if let Ok((fee_consumer, fee_industrial)) =
-                        crate::fee::decompose(e.tx.payload.fee_selector, e.tx.payload.fee)
-                    {
-                        acc.pending.consumer += e.tx.payload.amount_consumer + fee_consumer;
-                        acc.pending.industrial += e.tx.payload.amount_industrial + fee_industrial;
-                        acc.pending.nonce += 1;
-                        acc.pending.nonces.insert(e.tx.payload.nonce);
+            }
+            if batch.is_empty() {
+                break;
+            }
+            for e in batch {
+                let size = bincode::serialize(&e.tx)
+                    .map(|b| b.len() as u64)
+                    .unwrap_or(0);
+                let fpb = if size == 0 {
+                    0
+                } else {
+                    e.tx.payload.fee / size
+                };
+                #[cfg(feature = "telemetry")]
+                let _span = tracing::span!(
+                    tracing::Level::TRACE,
+                    "startup_rebuild",
+                    sender = %e.sender,
+                    nonce = e.nonce,
+                    fpb,
+                    mempool_size = bc
+                        .mempool_size
+                        .load(std::sync::atomic::Ordering::SeqCst)
+                )
+                .entered();
+                #[cfg(not(feature = "telemetry"))]
+                let _ = fpb;
+                if bc.accounts.contains_key(&e.sender) {
+                    bc.mempool.insert(
+                        (e.sender.clone(), e.nonce),
+                        MempoolEntry {
+                            tx: e.tx.clone(),
+                            timestamp_millis: e.timestamp_millis,
+                            timestamp_ticks: e.timestamp_ticks,
+                        },
+                    );
+                    bc.inc_mempool_size();
+                    if let Some(acc) = bc.accounts.get_mut(&e.sender) {
+                        if let Ok((fee_consumer, fee_industrial)) =
+                            crate::fee::decompose(e.tx.payload.fee_selector, e.tx.payload.fee)
+                        {
+                            acc.pending.consumer += e.tx.payload.amount_consumer + fee_consumer;
+                            acc.pending.industrial +=
+                                e.tx.payload.amount_industrial + fee_industrial;
+                            acc.pending.nonce += 1;
+                            acc.pending.nonces.insert(e.tx.payload.nonce);
+                        }
                     }
+                } else {
+                    missing_drop_total += 1;
                 }
-            } else {
-                expired_drop_total += 1;
             }
         }
+        let ttl_drop_total = bc.purge_expired();
+        let expired_drop_total = missing_drop_total + ttl_drop_total;
         #[cfg(not(feature = "telemetry"))]
         let _ = expired_drop_total;
         #[cfg(all(feature = "telemetry", not(feature = "telemetry-json")))]
@@ -919,6 +927,8 @@ impl Blockchain {
             "expired_drop_total",
             Some(expired_drop_total as u64),
         );
+        #[cfg(feature = "telemetry")]
+        telemetry::STARTUP_TTL_DROP_TOTAL.inc_by(ttl_drop_total);
         Ok(bc)
     }
 
@@ -1553,8 +1563,14 @@ impl Blockchain {
                 }
             }
             if !self.accounts.contains_key(sender) {
-                self.orphan_counter
-                    .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                if self
+                    .orphan_counter
+                    .load(std::sync::atomic::Ordering::SeqCst)
+                    > 0
+                {
+                    self.orphan_counter
+                        .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                }
             }
             #[cfg(feature = "telemetry-json")]
             log_event(log::Level::Info, "drop", sender, nonce, "dropped", None);
@@ -2512,6 +2528,11 @@ pub fn the_block(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("ErrMempoolFull", ErrMempoolFull::type_object(m.py()))?;
     m.add("ErrLockPoisoned", ErrLockPoisoned::type_object(m.py()))?;
     m.add("ErrPendingLimit", ErrPendingLimit::type_object(m.py()))?;
+    #[cfg(feature = "telemetry")]
+    {
+        m.add_function(wrap_pyfunction!(gather_metrics, m)?)?;
+        m.add_function(wrap_pyfunction!(serve_metrics, m)?)?;
+    }
     Ok(())
 }
 

--- a/tests/mempool_policy.rs
+++ b/tests/mempool_policy.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_range_loop)]
+
 use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(feature = "telemetry")]


### PR DESCRIPTION
## Summary
- separate startup TTL metric from missing-account drops and guard orphan counter decrement
- restore TTL env var after demo restart
- update telemetry doc anchors to `src/lib.rs#L1596-L1665` and `src/lib.rs#L1621-L1656`
- expose `gather_metrics` and `serve_metrics` to Python so demos and tests can assert telemetry

## Testing
- `cargo fmt --all -- --check`
- `black --check .`
- `ruff check .`
- `cargo test --features telemetry`
- `pytest -q`
- `maturin develop --release --features "pyo3/extension-module telemetry"`
- `./.venv/bin/python demo.py`

------
https://chatgpt.com/codex/tasks/task_e_6896a49e35d0832eb6c60e5aa187b1c4