### PR TITLE
Add purge loop context manager and saturating telemetry

### DIFF
--- a/.github/workflows/invariants.yml
+++ b/.github/workflows/invariants.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Formatting
         run: cargo fmt --all -- --check
       - name: Check anchors
-        run: python scripts/check_anchors.py
+        run: python scripts/check_anchors.py --md-anchors
       - name: Run tests
         id: vars
         run: |

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -9,6 +9,8 @@
 - `decode_payload(bytes)` decodes canonical payload bytes back into `RawTxPayload`.
 - `ShutdownFlag` and `PurgeLoopHandle` manage purge threads when used with
   `maybe_spawn_purge_loop`.
+- `PurgeLoop(bc)` context manager spawns the purge loop and triggers
+  shutdown on exit.
 - `maybe_spawn_purge_loop(bc, shutdown)` reads `TB_PURGE_LOOP_SECS` and returns
   a `PurgeLoopHandle` that joins the background TTL cleanup thread.
 - `Blockchain::panic_in_admission_after(step)` panics mid-admission for test harnesses;

--- a/AUDIT_NOTES.md
+++ b/AUDIT_NOTES.md
@@ -41,8 +41,14 @@
   bench `startup_rebuild` compares batched vs
   naive loops.
 - Cached serialized transaction sizes inside `MempoolEntry` so
-  `purge_expired` computes fee-per-byte without reserializing; added
-  `scripts/check_anchors.py` to CI to validate Markdown links.
+  `purge_expired` computes fee-per-byte without reserializing;
+  `scripts/check_anchors.py --md-anchors` now validates Markdown section
+  and Rust line links in CI.
+- Introduced Pythonic `PurgeLoop` context manager wrapping `ShutdownFlag`
+  and `PurgeLoopHandle`; `demo.py` and docs showcase `with PurgeLoop(bc):`.
+- `TTL_DROP_TOTAL` and `ORPHAN_SWEEP_TOTAL` counters saturate at
+  `u64::MAX`; tests prove `ShutdownFlag.trigger()` stops the purge loop
+  before overflow.
 - Archived `artifacts/fuzz.log` and `artifacts/migration.log` with accompanying
   `RISK_MEMO.md` capturing residual risk and review requirements.
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -175,8 +175,18 @@ pub fn canonical_payload_py(payload: RawTxPayload) -> Vec<u8> {
     canonical_payload_bytes(&payload)
 }
 
-/// Python helper that decodes canonical bytes into a [`RawTxPayload`].
-#[pyfunction(name = "decode_payload")]
+/// Decode canonical payload bytes into a :class:`RawTxPayload`.
+///
+/// Args:
+///     bytes (bytes): Serialized payload bytes produced by
+///         :func:`canonical_payload`.
+///
+/// Returns:
+///     RawTxPayload: Decoded payload structure.
+///
+/// Raises:
+///     ValueError: If ``bytes`` cannot be deserialized.
+#[pyfunction(name = "decode_payload", text_signature = "(bytes)")]
 pub fn decode_payload_py(bytes: Vec<u8>) -> PyResult<RawTxPayload> {
     bincode_config()
         .deserialize(&bytes)


### PR DESCRIPTION
## Summary
- add `PurgeLoop` Python context manager that auto-shuts down purge threads
- saturate telemetry counters and document new Python bindings
- validate Markdown anchors with optional `--md-anchors` flag
- synchronize README and handbooks with new purge-loop lifecycle and anchor checks

## Testing
- `python scripts/check_anchors.py --md-anchors`
- `cargo test --quiet --test purge_loop --test maybe_purge_loop`
- `cargo test --quiet --features telemetry --test purge_loop --test maybe_purge_loop`


------
https://chatgpt.com/codex/tasks/task_e_6898a6ab88a4832eb49609011a30d1b9