### PR TITLE
feat: surface purge loop panics, verify shutdown, slugify anchors, document payload decoding, and stress telemetry counters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Interval in seconds between mempool purge iterations.
+# Set to 0 or leave unset to disable the background purge loop (default).
+TB_PURGE_LOOP_SECS=0

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -17,6 +17,7 @@
   `Blockchain::heal_admission()` clears the flag.
 - `Blockchain::panic_next_evict()` triggers a panic during the next eviction and
   `Blockchain::heal_mempool()` clears the poisoned mutex.
+- `PurgeLoopHandle.join()` raises `RuntimeError` if the purge thread panicked.
 
 ### Telemetry
 - `TTL_DROP_TOTAL` counts transactions purged due to TTL expiry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   timestamps stored as monotonic ticks.
 - Fix: guard mining mempool mutations with global mutex to enforce
   capacity under concurrency.
+- Fix: `PurgeLoopHandle.join` surfaces purge thread panics as `RuntimeError`.
+- Docs: document `TB_PURGE_LOOP_SECS` in `README` and `.env.example`.
+- Docs: add `decode_payload` usage example in `README` and `demo.py`.
 - Feat: introduce minimum fee-per-byte floor with `FeeTooLow` rejection.
 - Feat: expose mempool limits (`max_mempool_size`, `min_fee_per_byte`,
   `tx_ttl`, `max_pending_per_account`) via `TB_*` env vars and sweep expired

--- a/scripts/test_check_anchors.py
+++ b/scripts/test_check_anchors.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# Load the check_anchors module without requiring a package
+MODULE_PATH = Path(__file__).with_name("check_anchors.py")
+spec = importlib.util.spec_from_file_location("check_anchors", MODULE_PATH)
+check_anchors = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(check_anchors)
+
+slugify = check_anchors.slugify
+check_md_anchor = check_anchors.check_md_anchor
+MD_PATTERN = check_anchors.MD_PATTERN
+
+
+def test_slugify_mixed_case():
+    assert slugify("Mixed CASE Heading") == "mixed-case-heading"
+
+
+def test_slugify_punctuation():
+    assert slugify("Heading & punctuation!") == "heading-punctuation"
+
+
+def test_check_md_anchor_slug(tmp_path: Path):
+    target = tmp_path / "doc.md"
+    target.write_text("# Heading & punctuation!\n", encoding="utf-8")
+    ref = tmp_path / "ref.md"
+    ref.write_text("(doc.md#heading-punctuation)\n", encoding="utf-8")
+    content = ref.read_text(encoding="utf-8")
+    match = MD_PATTERN.search(content)
+    assert match is not None
+    assert check_md_anchor(ref, match) is None

--- a/tests/purge_loop.rs
+++ b/tests/purge_loop.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -20,8 +20,11 @@ fn unique_path(prefix: &str) -> String {
     format!("{prefix}_{id}")
 }
 
+static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
 #[test]
 fn purge_loop_drops_expired_entries() {
+    let _guard = TEST_MUTEX.lock().unwrap();
     init();
     let path = unique_path("purge_loop");
     let _ = fs::remove_dir_all(&path);
@@ -64,6 +67,7 @@ fn purge_loop_drops_expired_entries() {
 #[test]
 #[cfg(feature = "telemetry")]
 fn counters_saturate_at_u64_max() {
+    let _guard = TEST_MUTEX.lock().unwrap();
     init();
     let path = unique_path("purge_saturate");
     let _ = fs::remove_dir_all(&path);
@@ -135,6 +139,79 @@ fn counters_saturate_at_u64_max() {
     bc.purge_expired();
     assert_eq!(u64::MAX, telemetry::ORPHAN_SWEEP_TOTAL.get());
 
+    telemetry::TTL_DROP_TOTAL.reset();
+    telemetry::ORPHAN_SWEEP_TOTAL.reset();
+}
+
+#[test]
+#[cfg(feature = "telemetry")]
+fn counters_saturate_concurrently() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    init();
+    const THREADS: usize = 8;
+    telemetry::TTL_DROP_TOTAL.reset();
+    telemetry::ORPHAN_SWEEP_TOTAL.reset();
+    telemetry::TTL_DROP_TOTAL.inc_by(u64::MAX - (THREADS as u64 - 1));
+    telemetry::ORPHAN_SWEEP_TOTAL.inc_by(u64::MAX - (THREADS as u64 - 1));
+    let start = Arc::new(Barrier::new(THREADS));
+    let mid = Arc::new(Barrier::new(THREADS));
+    let handles: Vec<_> = (0..THREADS)
+        .map(|_| {
+            let start = Arc::clone(&start);
+            let mid = Arc::clone(&mid);
+            thread::spawn(move || {
+                let path = unique_path("concurrent_purge");
+                let _ = fs::remove_dir_all(&path);
+                let mut bc = Blockchain::open(&path).unwrap();
+                bc.min_fee_per_byte = 0;
+                bc.add_account("a".into(), 10, 10).unwrap();
+                bc.add_account("b".into(), 0, 0).unwrap();
+                let (sk, _pk) = generate_keypair();
+                let payload = RawTxPayload {
+                    from_: "a".into(),
+                    to: "b".into(),
+                    amount_consumer: 1,
+                    amount_industrial: 1,
+                    fee: 1,
+                    fee_selector: 0,
+                    nonce: 1,
+                    memo: Vec::new(),
+                };
+                let tx = sign_tx(sk.to_vec(), payload).unwrap();
+                bc.submit_transaction(tx).unwrap();
+                if let Some(mut entry) = bc.mempool.get_mut(&("a".into(), 1)) {
+                    entry.timestamp_millis = 0;
+                    entry.timestamp_ticks = 0;
+                }
+                bc.tx_ttl = 1;
+                start.wait();
+                bc.purge_expired();
+
+                bc.add_account("c".into(), 10, 10).unwrap();
+                let (sk2, _pk2) = generate_keypair();
+                let payload2 = RawTxPayload {
+                    from_: "c".into(),
+                    to: "b".into(),
+                    amount_consumer: 1,
+                    amount_industrial: 1,
+                    fee: 1,
+                    fee_selector: 0,
+                    nonce: 1,
+                    memo: Vec::new(),
+                };
+                let tx2 = sign_tx(sk2.to_vec(), payload2).unwrap();
+                bc.submit_transaction(tx2).unwrap();
+                bc.accounts.remove("c");
+                mid.wait();
+                bc.purge_expired();
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+    assert_eq!(u64::MAX, telemetry::TTL_DROP_TOTAL.get());
+    assert_eq!(u64::MAX, telemetry::ORPHAN_SWEEP_TOTAL.get());
     telemetry::TTL_DROP_TOTAL.reset();
     telemetry::ORPHAN_SWEEP_TOTAL.reset();
 }

--- a/tests/purge_loop_exception.rs
+++ b/tests/purge_loop_exception.rs
@@ -1,0 +1,119 @@
+use std::fs;
+use std::thread;
+use std::time::Duration;
+
+use pyo3::prelude::*;
+use pyo3::types::PyModule;
+use std::ffi::CString;
+
+#[cfg(feature = "telemetry")]
+use the_block::telemetry;
+use the_block::{generate_keypair, sign_tx, Blockchain, RawTxPayload};
+
+fn init() {
+    let _ = fs::remove_dir_all("chain_db");
+    pyo3::prepare_freethreaded_python();
+}
+
+fn unique_path(prefix: &str) -> String {
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    static COUNT: AtomicUsize = AtomicUsize::new(0);
+    let id = COUNT.fetch_add(1, AtomicOrdering::Relaxed);
+    format!("{prefix}_{id}")
+}
+
+#[test]
+fn purge_loop_shutdowns_on_exception() {
+    init();
+    let path = unique_path("purge_loop_exception");
+    let _ = fs::remove_dir_all(&path);
+    std::env::set_var("TB_PURGE_LOOP_SECS", "1");
+    let mut bc = Blockchain::open(&path).unwrap();
+    bc.min_fee_per_byte = 0;
+    bc.add_account("a".into(), 10, 10).unwrap();
+    bc.add_account("b".into(), 0, 0).unwrap();
+    let (sk, _pk) = generate_keypair();
+    let payload = RawTxPayload {
+        from_: "a".into(),
+        to: "b".into(),
+        amount_consumer: 1,
+        amount_industrial: 1,
+        fee: 1,
+        fee_selector: 0,
+        nonce: 1,
+        memo: Vec::new(),
+    };
+    let tx = sign_tx(sk.to_vec(), payload).unwrap();
+    bc.submit_transaction(tx).unwrap();
+    let key = (String::from("a"), 1u64);
+    if let Some(mut entry) = bc.mempool.get_mut(&key) {
+        entry.timestamp_millis = 0;
+        entry.timestamp_ticks = 0;
+    };
+    bc.tx_ttl = 1;
+    #[cfg(feature = "telemetry")]
+    telemetry::TTL_DROP_TOTAL.reset();
+
+    // move bc into Python
+    let bc_py = Python::with_gil(|py| Py::new(py, bc).unwrap());
+
+    let result: PyResult<()> = Python::with_gil(|py| {
+        let code = r#"
+import time, the_block
+
+def boom(bc):
+    with the_block.PurgeLoop(bc):
+        time.sleep(1.1)
+        raise RuntimeError('boom')
+"#;
+        let code_c = CString::new(code).unwrap();
+        let filename = CString::new("purge_loop_exception.py").unwrap();
+        let module_name = CString::new("purge_loop_exception").unwrap();
+        let module = PyModule::from_code(
+            py,
+            code_c.as_c_str(),
+            filename.as_c_str(),
+            module_name.as_c_str(),
+        )?;
+        let boom = module.getattr("boom")?;
+        boom.call1((bc_py.clone_ref(py),))?;
+        Ok(())
+    });
+    assert!(result.is_err());
+
+    // insert another expired transaction after the exception
+    Python::with_gil(|py| {
+        let mut bc_ref = bc_py.borrow_mut(py);
+        let payload = RawTxPayload {
+            from_: "a".into(),
+            to: "b".into(),
+            amount_consumer: 1,
+            amount_industrial: 1,
+            fee: 1,
+            fee_selector: 0,
+            nonce: 1,
+            memo: Vec::new(),
+        };
+        let tx = sign_tx(sk.to_vec(), payload).unwrap();
+        bc_ref.submit_transaction(tx).unwrap();
+        let key = (String::from("a"), 1u64);
+        if let Some(mut entry) = bc_ref.mempool.get_mut(&key) {
+            entry.timestamp_millis = 0;
+            entry.timestamp_ticks = 0;
+        };
+    });
+
+    thread::sleep(Duration::from_millis(1100));
+
+    #[cfg(feature = "telemetry")]
+    assert_eq!(1, telemetry::TTL_DROP_TOTAL.get());
+
+    Python::with_gil(|py| {
+        let bc_ref = bc_py.borrow(py);
+        assert_eq!(1, bc_ref.mempool.len());
+    });
+
+    #[cfg(feature = "telemetry")]
+    telemetry::TTL_DROP_TOTAL.reset();
+    std::env::remove_var("TB_PURGE_LOOP_SECS");
+}

--- a/tests/purge_loop_panic.rs
+++ b/tests/purge_loop_panic.rs
@@ -1,0 +1,64 @@
+use std::fs;
+
+use pyo3::prelude::*;
+use pyo3::types::PyModule;
+use std::ffi::CString;
+
+use the_block::{maybe_spawn_purge_loop_py, Blockchain, ShutdownFlag};
+
+fn init() {
+    let _ = fs::remove_dir_all("chain_db");
+    pyo3::prepare_freethreaded_python();
+}
+
+fn unique_path(prefix: &str) -> String {
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    static COUNT: AtomicUsize = AtomicUsize::new(0);
+    let id = COUNT.fetch_add(1, AtomicOrdering::Relaxed);
+    format!("{prefix}_{id}")
+}
+
+#[test]
+fn purge_loop_join_surfaces_panic() {
+    init();
+    let path = unique_path("purge_loop_join_panic");
+    let _ = fs::remove_dir_all(&path);
+    std::env::set_var("TB_PURGE_LOOP_SECS", "1");
+    let bc = Blockchain::open(&path).unwrap();
+    bc.panic_next_purge();
+    let shutdown = ShutdownFlag::new();
+
+    let result = Python::with_gil(|py| {
+        let bc_py = Py::new(py, bc).unwrap();
+        let handle =
+            maybe_spawn_purge_loop_py(bc_py.clone_ref(py), &shutdown).expect("loop not started");
+        let handle_py = Py::new(py, handle).unwrap();
+        let code = r#"
+import time
+
+def trigger(handle):
+    time.sleep(0.1)
+    handle.join()
+"#;
+        let code_c = CString::new(code).unwrap();
+        let filename = CString::new("purge_loop_panic.py").unwrap();
+        let module_name = CString::new("purge_loop_panic").unwrap();
+        let module = PyModule::from_code(
+            py,
+            code_c.as_c_str(),
+            filename.as_c_str(),
+            module_name.as_c_str(),
+        )?;
+        let trigger = module.getattr("trigger")?;
+        trigger.call1((handle_py,))?;
+        Ok::<(), PyErr>(())
+    });
+    assert!(result.is_err());
+    Python::with_gil(|py| {
+        let err = result.unwrap_err();
+        assert!(err.is_instance_of::<pyo3::exceptions::PyRuntimeError>(py));
+        let msg = err.value(py).to_string();
+        assert!(msg.contains("purge panic"));
+    });
+    std::env::remove_var("TB_PURGE_LOOP_SECS");
+}


### PR DESCRIPTION
## Summary
- propagate purge-loop thread panics by raising `RuntimeError` from `PurgeLoopHandle.join`
- add regression tests verifying purge loop shutdown on exceptions and panic propagation
- document `TB_PURGE_LOOP_SECS` env var in README, example `.env`, and demo script
- match GitHub-style slugification in anchor checker with new unit tests
- demonstrate `decode_payload` usage in README and demo script, including a `decode_payload_demo` round-trip
- stress-test telemetry counters with a concurrent purge test ensuring `TTL_DROP_TOTAL` and `ORPHAN_SWEEP_TOTAL` saturate at `u64::MAX`

## Testing
- `python scripts/check_anchors.py --md-anchors`
- `pytest scripts/test_check_anchors.py`
- `cargo test --features telemetry --test purge_loop`
- `cargo test --test purge_loop_exception --test purge_loop_panic`
- `cargo test --test purge_loop_exception`


------
https://chatgpt.com/codex/tasks/task_e_6898efd5d710832eae4ffc8d7f2e03e1