### PR TITLE
Stop purge loop when handle dropped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,8 +165,9 @@ CI is GitHub Actions; each push/PR runs **seven** jobs:
 5. **Udeps** — `cargo +nightly udeps --all-targets` ensures no unused dependencies.
 6. **Fuzz Smoke** — 1 k iterations per target to catch obvious regressions.
 7. **Wheel Build** — `maturin build` and `auditwheel show` to confirm manylinux compliance.
-8. **Isolation** — each test uses `unique_path` so every `Blockchain` instance
-   writes to a fresh temp directory and removes it on drop.
+8. **Isolation** — each test uses `tests::util::temp::temp_dir` so every
+   `Blockchain` instance writes to a fresh temp directory that is removed
+   automatically when the handle drops.
 9. **Replay Guard** — `test_replay_attack_prevention` exercises the
    `(sender, nonce)` dedup logic; duplicates must be rejected.
 

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -21,7 +21,9 @@
 - `Blockchain::panic_next_evict()` triggers a panic during the next eviction and
   `Blockchain::heal_mempool()` clears the poisoned mutex.
 - `PurgeLoopHandle.join()` raises `RuntimeError` if the purge thread panicked
-  and includes a backtrace when `RUST_BACKTRACE` is set.
+  and setting `RUST_BACKTRACE=1` appends a Rust backtrace to the panic message.
+- Dropping `PurgeLoopHandle` triggers shutdown automatically if
+  `ShutdownFlag.trigger()` was not called.
 
 ### Telemetry
 - `TTL_DROP_TOTAL` counts transactions purged due to TTL expiry.

--- a/Agents-Sup.md
+++ b/Agents-Sup.md
@@ -29,7 +29,8 @@ This document extends `AGENTS.md` with a deep dive into the project's long‑ter
   chain, account map and emission counters. Schema version = 3.
 * `Blockchain` tracks its `path` and its `Drop` impl removes the directory.
   `Blockchain::new(path)` expects a unique temp directory; tests use
-  `unique_path()` to avoid cross-test leakage.
+  `tests::util::temp::temp_dir()` to avoid cross-test leakage and ensure
+  automatic cleanup.
 
 ### Mempool Concurrency
 * A global `mempool_mutex` guards all mempool mutations before the per-sender
@@ -80,8 +81,8 @@ This document extends `AGENTS.md` with a deep dive into the project's long‑ter
 ### Tests
 * Rust property tests under `tests/test_chain.rs` validate invariants (balances never
   negative, reward decay, duplicate TxID rejection, etc.).
-* Fixtures create isolated directories via `unique_path()` and clean them after
-  execution so runs remain hermetic.
+* Fixtures create isolated directories via `tests::util::temp::temp_dir()` and
+  clean them automatically after execution so runs remain hermetic.
 * `test_replay_attack_prevention` asserts duplicate `(sender, nonce)` pairs are rejected.
 * `tests/test_interop.py` confirms Python and Rust encode transactions identically.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@
 - Fix: guard mining mempool mutations with global mutex to enforce
   capacity under concurrency.
 - Fix: `PurgeLoopHandle.join` surfaces purge thread panics as `RuntimeError`,
-  capturing a backtrace when `RUST_BACKTRACE` is set.
+  appending a Rust backtrace when `RUST_BACKTRACE=1`.
+- Fix: dropping `PurgeLoopHandle` triggers its shutdown flag to halt the
+  purge thread when `ShutdownFlag.trigger()` is omitted.
 - Docs: document `TB_PURGE_LOOP_SECS` in `README` and `.env.example`.
 - Docs: add `decode_payload` usage example in `README` and `demo.py`.
 - Feat: introduce minimum fee-per-byte floor with `FeeTooLow` rejection.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +718,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -1011,10 +1094,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -1055,6 +1153,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1202,12 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1154,6 +1283,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "thiserror",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ base64 = "0.22"
 proptest = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 csv = "1"
+serial_test = "3"
 
 [[bench]]
 name = "startup_rebuild"

--- a/docs/audit_handbook.md
+++ b/docs/audit_handbook.md
@@ -8,7 +8,7 @@ An automated audit matrix (`xtask gen-audit-matrix`) maps every requirement ID t
 - Build steps print a machine-readable nonce containing the git commit, timestamp, and dependency hashes.
 - Tests start from a deliberately "dirty" state with leftover DB files and temporary garbage to verify correct cleanup.
 - Each `Blockchain::new(path)` instance writes to its own temp directory via
-  `unique_path` and deletes it after tests, proving isolation.
+  `tests::util::temp::temp_dir` and deletes it after tests, proving isolation.
 
 ## 2. Attack Surface Exploration
 - Begin by attacking the least documented paths. Introduce corrupted database files, malformed blocks, and replayed transactions.

--- a/docs/detailed_updates.md
+++ b/docs/detailed_updates.md
@@ -78,9 +78,10 @@ curl -s localhost:9000/metrics \
   | grep -E 'startup_ttl_drop_total|ttl_drop_total|orphan_sweep_total|lock_poison_total|tx_rejected_total'
 ```
 - **Documentation** – Project disclaimers moved to README and Agents-Sup now details schema migrations and invariant anchors.
-- **Test Harness Isolation** – `Blockchain::new(path)` now provisions a unique temp
-  directory per instance and removes it on drop. Fixtures call `unique_path` so
-  parallel tests cannot interfere.
+- **Test Harness Isolation** – `Blockchain::new(path)` now provisions a unique
+  temp directory per instance and removes it on drop. Fixtures call
+  `tests::util::temp::temp_dir` so parallel tests cannot interfere and cleanup
+  happens automatically.
 - **Replay Guard Test** – Reactivated `test_replay_attack_prevention` to prove duplicates
   with the same `(sender, nonce)` are rejected.
 - **Mempool Hardening** – Admission now uses an atomic size counter and binary

--- a/scripts/check_anchors.py
+++ b/scripts/check_anchors.py
@@ -31,7 +31,7 @@ MD_PATTERN = re.compile(
 
 
 def check_rust_anchor(md_path: Path, match: re.Match[str]) -> str | None:
-    rel_path = match.group("path")
+    rel_path = match.group("path").replace("\\", "/")
     start = int(match.group("start"))
     end = int(match.group("end") or start)
 
@@ -82,7 +82,7 @@ def slugify(text: str) -> str:
 
 
 def check_md_anchor(md_path: Path, match: re.Match[str]) -> str | None:
-    rel_path = match.group("path")
+    rel_path = match.group("path").replace("\\", "/")
     section = match.group("section")
     target = (md_path.parent / rel_path).resolve()
     if not target.exists():
@@ -115,7 +115,7 @@ def main() -> int:
     for md in ROOT.rglob("*.md"):
         if any(part in {"target", ".git", "advisory-db", ".venv"} for part in md.parts):
             continue
-        content = md.read_text(encoding="utf-8")
+        content = md.read_text(encoding="utf-8").replace("\\", "/")
         for match in RUST_PATTERN.finditer(content):
             if err := check_rust_anchor(md, match):
                 errors.append(err)

--- a/scripts/test_check_anchors.py
+++ b/scripts/test_check_anchors.py
@@ -13,6 +13,8 @@ spec.loader.exec_module(check_anchors)
 slugify = check_anchors.slugify
 check_md_anchor = check_anchors.check_md_anchor
 MD_PATTERN = check_anchors.MD_PATTERN
+check_rust_anchor = check_anchors.check_rust_anchor
+RUST_PATTERN = check_anchors.RUST_PATTERN
 
 
 def test_slugify_mixed_case():
@@ -44,3 +46,17 @@ def test_check_md_anchor_slug(tmp_path: Path):
     match = MD_PATTERN.search(content)
     assert match is not None
     assert check_md_anchor(ref, match) is None
+
+
+def test_rust_anchor_windows_path(tmp_path: Path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "lib.rs").write_text("fn main() {}\n", encoding="utf-8")
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    md = docs / "ref.md"
+    md.write_text("(..\\src\\lib.rs#L1)\n", encoding="utf-8")
+    content = md.read_text(encoding="utf-8").replace("\\", "/")
+    match = RUST_PATTERN.search(content)
+    assert match is not None
+    assert check_rust_anchor(md, match) is None

--- a/src/blockchain/difficulty.rs
+++ b/src/blockchain/difficulty.rs
@@ -23,8 +23,8 @@ pub fn expected_difficulty(chain: &[Block]) -> u64 {
     if slice.len() < 2 {
         return current;
     }
-    let first_ts = slice.first().unwrap().timestamp_millis;
-    let last_ts = slice.last().unwrap().timestamp_millis;
+    let first_ts = slice[0].timestamp_millis;
+    let last_ts = slice[slice.len() - 1].timestamp_millis;
     if first_ts == 0 || last_ts <= first_ts {
         return current;
     }

--- a/tests/temp_helper.rs
+++ b/tests/temp_helper.rs
@@ -1,0 +1,17 @@
+mod util;
+use util::temp::temp_dir;
+
+#[test]
+fn temp_dir_auto_cleans_on_drop() {
+    let dir = temp_dir("temp_dir_cleanup");
+    let path = dir.path().to_path_buf();
+    assert!(
+        path.exists(),
+        "temp dir should exist while TempDir is alive"
+    );
+    drop(dir);
+    assert!(
+        !path.exists(),
+        "temp dir should be removed after TempDir is dropped"
+    );
+}

--- a/tests/test_purge_loop_env.py
+++ b/tests/test_purge_loop_env.py
@@ -4,27 +4,36 @@ import the_block
 
 
 def test_invalid_env_raises(tmp_path):
-    os.environ['TB_PURGE_LOOP_SECS'] = 'abc'
+    os.environ["TB_PURGE_LOOP_SECS"] = "abc"
     bc = the_block.Blockchain.with_difficulty(str(tmp_path), 1)
     flag = the_block.ShutdownFlag()
     with pytest.raises(ValueError) as exc:
         the_block.maybe_spawn_purge_loop(bc, flag)
-    assert 'TB_PURGE_LOOP_SECS' in str(exc.value)
-    del os.environ['TB_PURGE_LOOP_SECS']
+    assert "TB_PURGE_LOOP_SECS" in str(exc.value)
+    del os.environ["TB_PURGE_LOOP_SECS"]
 
 
 def test_zero_env_raises(tmp_path):
-    os.environ['TB_PURGE_LOOP_SECS'] = '0'
+    os.environ["TB_PURGE_LOOP_SECS"] = "0"
     bc = the_block.Blockchain.with_difficulty(str(tmp_path), 1)
     flag = the_block.ShutdownFlag()
     with pytest.raises(ValueError):
         the_block.maybe_spawn_purge_loop(bc, flag)
-    del os.environ['TB_PURGE_LOOP_SECS']
+    del os.environ["TB_PURGE_LOOP_SECS"]
+
+
+def test_negative_env_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("TB_PURGE_LOOP_SECS", "-5")
+    bc = the_block.Blockchain.with_difficulty(str(tmp_path), 1)
+    flag = the_block.ShutdownFlag()
+    with pytest.raises(ValueError) as exc:
+        the_block.maybe_spawn_purge_loop(bc, flag)
+    assert "TB_PURGE_LOOP_SECS" in str(exc.value)
 
 
 def test_missing_env_raises(tmp_path):
-    if 'TB_PURGE_LOOP_SECS' in os.environ:
-        del os.environ['TB_PURGE_LOOP_SECS']
+    if "TB_PURGE_LOOP_SECS" in os.environ:
+        del os.environ["TB_PURGE_LOOP_SECS"]
     bc = the_block.Blockchain.with_difficulty(str(tmp_path), 1)
     flag = the_block.ShutdownFlag()
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- ensure PurgeLoopHandle triggers its shutdown flag on drop
- clone shutdown flag into purge loop thread and handle for safe auto-shutdown
- serialize purge loop tests and verify dropping handle without trigger stops thread
- reject negative `TB_PURGE_LOOP_SECS` via Python and Rust tests
- normalize Windows path separators in `check_anchors.py` and add regression test
- document `tests::util::temp::temp_dir` helper and prove temp dir auto-cleans
- document `RUST_BACKTRACE=1` diagnostics for purge-loop panics

## Testing
- `cargo test --test maybe_purge_loop`
- `cargo test --test purge_loop_panic`
- `cargo test --test temp_helper`
- `.venv/bin/python -m pytest tests/test_purge_loop_env.py -q`
- `.venv/bin/python -m pytest scripts/test_check_anchors.py -q`
- `.venv/bin/python scripts/check_anchors.py --md-anchors`
- `TB_PURGE_LOOP_SECS=1 timeout 20 ./.venv/bin/python demo.py`
- `cargo clippy --all-targets --all-features` *(fails: missing tests/vectors.rs and type errors in test_chain.rs)*

------
https://chatgpt.com/codex/tasks/task_e_689a1f098fdc832e98e8d977df6efb2a