### PR TITLE
feat: link macOS Python runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ ln -sf ../../githooks/pre-commit .git/hooks/pre-commit
 - `PYTHONUNBUFFERED` — set to `1` for deterministic Python logs in demos and tests.
 - `TB_DEMO_MANUAL_PURGE` — set to `1` to require an explicit purge-loop shutdown in `demo.py`.
 
-> **Tip:** After any `.rs` or `Cargo.toml` change, run `maturin develop --release --features telemetry` to rebuild and re‑install the Python module in‑place.
+ > **Tip:** After any `.rs` or `Cargo.toml` change, run `maturin develop --release --features telemetry` to rebuild and re‑install the Python module in‑place. The `pytest` harness will call `maturin develop` automatically if `the_block` is missing, but running it yourself keeps the extension fresh during development.
 
 ---
 
@@ -180,9 +180,10 @@ ln -sf ../../githooks/pre-commit .git/hooks/pre-commit
 3. **Cross‑Language Determinism** — Python ↔ Rust serialization byte‑for‑byte equality for 100 random payloads (`tests/test_determinism.py`).
 4. **Fuzzing** (`cargo fuzz run verify_sig`) — signature verification stability, 10 k iterations on CI.
 5. **Benchmarks** (Criterion) — `verify_signature` must stay < 50 µs median on Apple M2.
-6. **Demo Integration** — `cargo test --release demo_runs_clean` runs `demo.py`; it defaults `TB_PURGE_LOOP_SECS=1` when unset, forces `PYTHONUNBUFFERED=1`, and leaves `TB_DEMO_MANUAL_PURGE` empty; logs are captured on failure. The demo auto-installs `the_block` with `maturin` if the module is missing.
+6. **Pytest Auto-Build** — `tests/conftest.py` runs `maturin develop` if `import the_block` fails, so Python tests can run without manual setup.
+7. **Demo Integration** — `cargo test --release demo_runs_clean` runs `demo.py`; it defaults `TB_PURGE_LOOP_SECS=1` when unset, forces `PYTHONUNBUFFERED=1`, and leaves `TB_DEMO_MANUAL_PURGE` empty; logs are captured on failure. The demo auto-installs `the_block` with `maturin` if the module is missing.
 
-7. **Lock-Poison Helper** — use `poison_mempool(bc)` to simulate a poisoned mutex and exercise `ERR_LOCK_POISON` and `lock_poison_total` paths.
+8. **Lock-Poison Helper** — use `poison_mempool(bc)` to simulate a poisoned mutex and exercise `ERR_LOCK_POISON` and `lock_poison_total` paths.
 
 Run all locally via:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 resolver = "2"
  
 [dependencies]
-pyo3 = { version = "0.24.2", default-features = false, features = ["macros"], optional = false }
+pyo3 = { version = "0.24.2", default-features = false, features = ["macros", "auto-initialize"], optional = false }
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 blake3 = "1"
@@ -33,7 +33,7 @@ telemetry = ["log", "prometheus", "tracing", "once_cell"]
 telemetry-json = ["telemetry"]
 
 [package.metadata.maturin]
-features = ["pyo3/extension-module", "telemetry"]
+features = ["pyo3/extension-module", "pyo3/auto-initialize", "telemetry"]
 
 [dev-dependencies]
 logtest = "2"

--- a/README.md
+++ b/README.md
@@ -139,6 +139,29 @@ preventing state leakage between cases. These directories are removed
 automatically when their handle is dropped.
 CI runs all of the above across **Linux‑glibc 2.34, macOS 12, and Windows 11 (WSL 2)**.  A red badge on `main` blocks merges.
 
+### macOS Python framework
+
+`pyo3` looks for the active Python when compiling. On macOS the dynamic
+loader may fail with `dyld: Library not loaded: @rpath/libpython*.dylib`
+if the build linked against a different interpreter than the one in your
+virtual environment. Export `PYO3_PYTHON` and `PYTHONHOME` before building
+to select the correct interpreter. The build script adds `$PYTHONHOME/lib`
+to the binary's `rpath` so `cargo run` can find `libpython` at runtime:
+
+```bash
+export PYO3_PYTHON=$(python3 -c 'import sys; print(sys.executable)')
+export PYTHONHOME=$(python3 -c 'import sys, pathlib; print(pathlib.Path(sys.executable).resolve().parents[1])')
+cargo build
+cargo run --bin node -- --help
+```
+
+Verify that the expected dynamic library exists in the selected Python
+home:
+
+```bash
+ls "$PYTHONHOME"/lib | grep libpython
+```
+
 ---
 
 ## Node CLI and JSON-RPC

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,12 @@ use std::{env, fs, path::Path};
 
 fn main() {
     println!("cargo:rerun-if-changed=src/constants.rs");
+    println!("cargo:rerun-if-env-changed=PYTHONHOME");
+    if cfg!(target_os = "macos") {
+        if let Ok(py_home) = env::var("PYTHONHOME") {
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{}/lib", py_home);
+        }
+    }
     if !include_str!("src/constants.rs").is_ascii() {
         println!(
             "::error file=src/constants.rs,line=1,col=1::Non-ASCII detected in consensus file"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,37 +16,48 @@ def _ensure_maturin() -> None:
         )
 
 
-def pytest_sessionstart(session):
+def _build_extension() -> None:
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    _ensure_maturin()
+    env = os.environ.copy()
+    env["MATURIN_PYTHON"] = sys.executable
+    env["PYO3_PYTHON"] = sys.executable
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "maturin",
+            "develop",
+            "--release",
+            "-F",
+            "pyo3/extension-module",
+            "-F",
+            "telemetry",
+        ],
+        cwd=repo_root,
+        check=True,
+        env=env,
+    )
+    venv_site = (
+        repo_root
+        / ".venv"
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+    sys.path.append(str(venv_site))
+
+
+def _ensure_extension() -> None:
     try:
         importlib.import_module("the_block")
     except ModuleNotFoundError:
-        repo_root = pathlib.Path(__file__).resolve().parents[1]
-        _ensure_maturin()
-        env = os.environ.copy()
-        env["MATURIN_PYTHON"] = sys.executable
-        env["PYO3_PYTHON"] = sys.executable
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "maturin",
-                "develop",
-                "--release",
-                "-F",
-                "pyo3/extension-module",
-                "-F",
-                "telemetry",
-            ],
-            cwd=repo_root,
-            check=True,
-            env=env,
-        )
-        venv_site = (
-            repo_root
-            / ".venv"
-            / "lib"
-            / f"python{sys.version_info.major}.{sys.version_info.minor}"
-            / "site-packages"
-        )
-        sys.path.append(str(venv_site))
+        _build_extension()
         importlib.import_module("the_block")
+
+
+_ensure_extension()
+
+
+def pytest_sessionstart(session):
+    _ensure_extension()


### PR DESCRIPTION
## Summary
- enable PyO3 auto initialization and extension-module features for maturin builds
- embed macOS Python home into rpath to avoid dyld errors
- document macOS steps for selecting Python and verifying libpython
- automatically build the_block extension in pytest when missing and document the auto-build flow

## Testing
- `cargo fmt --all -- --check`
- `black --check tests/conftest.py`
- `ruff check tests/conftest.py`
- `python scripts/check_anchors.py --md-anchors`
- `cargo build`
- `cargo run --bin node -- --help`
- `cargo test --release`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fbb79ffc4832e8b46b3d06d756b02