### PR TITLE
Refine RPC error handling and fix mempool borrow

### DIFF
--- a/node/src/compute_market/scheduler.rs
+++ b/node/src/compute_market/scheduler.rs
@@ -550,6 +550,8 @@ impl SchedulerState {
                                 reputation: new_rep,
                                 capability: current.capability.clone(),
                                 priority: current.priority,
+                                start_ts: current_ts(),
+                                expected_secs: current.expected_secs,
                             },
                         );
                         self.active_by_rep.push(Reverse(ActiveRepEntry {
@@ -1096,6 +1098,7 @@ mod tests {
             priority: Priority::Low,
             enqueue_ts: current_ts() - 10,
             effective_priority: 0,
+            expected_secs: 0,
         };
         let mut q2 = QueuedJob {
             job_id: "high".into(),
@@ -1104,6 +1107,7 @@ mod tests {
             priority: Priority::High,
             enqueue_ts: current_ts(),
             effective_priority: 0,
+            expected_secs: 0,
         };
         set_aging_rate(1.0);
         set_max_priority_boost(5.0);

--- a/node/src/governance/params.rs
+++ b/node/src/governance/params.rs
@@ -337,7 +337,7 @@ fn apply_heuristic_mu(v: i64, p: &mut Params) -> Result<(), ()> {
 }
 
 pub fn registry() -> &'static [ParamSpec] {
-    static REGS: [ParamSpec; 25] = [
+    static REGS: [ParamSpec; 28] = [
         ParamSpec {
             key: ParamKey::SnapshotIntervalSecs,
             default: 30,

--- a/node/src/provenance.rs
+++ b/node/src/provenance.rs
@@ -95,7 +95,7 @@ fn decode_signature(sig_hex: &str) -> Option<Signature> {
     }
     let mut arr = [0u8; SIGNATURE_LENGTH];
     arr.copy_from_slice(&bytes);
-    Signature::from_bytes(&arr).ok()
+    Some(Signature::from_bytes(&arr))
 }
 
 /// Refresh the cached release signer list from the configured sources.

--- a/node/src/rpc/peer.rs
+++ b/node/src/rpc/peer.rs
@@ -5,7 +5,9 @@ use libp2p::PeerId;
 
 pub fn rebate_status(params: Params) -> Result<BoxFuture<Result<String>>> {
     let (peer, threshold, epoch): (String, u64, u64) = params.parse()?;
-    let peer_id = PeerId::from_bytes(&hex::decode(peer)?)
+    let peer_bytes =
+        hex::decode(&peer).map_err(|e| jsonrpc_core::Error::invalid_params(e.to_string()))?;
+    let peer_id = PeerId::from_bytes(&peer_bytes)
         .map_err(|e| jsonrpc_core::Error::invalid_params(e.to_string()))?;
     let eligible = uptime::eligible(&peer_id, threshold, epoch);
     Ok(Box::pin(async move { Ok(eligible.to_string()) }))
@@ -13,7 +15,9 @@ pub fn rebate_status(params: Params) -> Result<BoxFuture<Result<String>>> {
 
 pub fn rebate_claim(params: Params) -> Result<BoxFuture<Result<String>>> {
     let (peer, threshold, epoch, reward): (String, u64, u64, u64) = params.parse()?;
-    let peer_id = PeerId::from_bytes(&hex::decode(peer)?)
+    let peer_bytes =
+        hex::decode(&peer).map_err(|e| jsonrpc_core::Error::invalid_params(e.to_string()))?;
+    let peer_id = PeerId::from_bytes(&peer_bytes)
         .map_err(|e| jsonrpc_core::Error::invalid_params(e.to_string()))?;
     let res = uptime::claim(peer_id, threshold, epoch, reward)
         .map(|v| v.to_string())

--- a/node/src/vm/opcodes.rs
+++ b/node/src/vm/opcodes.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 /// Core VM opcodes.
-#[derive(Clone, Copy, Serialize, Debug)]
+#[derive(Clone, Copy, Serialize, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum OpCode {
     Halt = 0x00,

--- a/node/tests/coinbase_builder.rs
+++ b/node/tests/coinbase_builder.rs
@@ -1,0 +1,15 @@
+use serial_test::serial;
+use the_block::Blockchain;
+
+mod util;
+
+#[test]
+#[serial]
+fn coinbase_tip_defaults_to_zero() {
+    let dir = util::temp::temp_dir("coinbase_tip");
+    let mut bc = Blockchain::new(dir.path().to_str().expect("path"));
+    bc.add_account("miner".into(), 0, 0).expect("add miner");
+
+    let block = bc.mine_block("miner").expect("mine block");
+    assert_eq!(block.transactions[0].tip, 0);
+}

--- a/tools/log_indexer.rs
+++ b/tools/log_indexer.rs
@@ -252,12 +252,7 @@ fn decrypt_message(key: &Key, data: &str, nonce: &[u8]) -> Option<String> {
 }
 
 fn derive_encryption_key(passphrase: &str) -> Key {
-    let mut key_bytes = [0u8; 32];
-    derive_key(
-        "the-block-log-indexer",
-        passphrase.as_bytes(),
-        &mut key_bytes,
-    );
+    let key_bytes = derive_key("the-block-log-indexer", passphrase.as_bytes());
     Key::clone_from_slice(&key_bytes)
 }
 


### PR DESCRIPTION
## Summary
- replace the RPC client surface with a dedicated `RpcClientError`, update wallet QoS handling, and extend the client test module
- route jurisdiction policy, log search, and updater failures through the new error helpers while exercising them with focused regression tests
- rework SimpleDb column-family tracking, streamline the compute-market helpers (SNARK placeholder and scheduler metadata), and fix the mempool admission borrow by splitting account and guard access

## Testing
- `cargo test -p the_block call_returns_fault_injection_error -- --nocapture` *(fails: workspace build terminated by the linker being killed)*
- `cargo test -p the_block policy_diff_reports_missing_pack -- --nocapture` *(fails: build blocked by unrelated gov/bin compile error and linker OOM)*
- `cargo test -p the_block encode_rows_reports_json_error -- --nocapture` *(fails: wallet binary compile errors and linker OOM)*
- `cargo test -p the_block map_search_error_handles_json_failure -- --nocapture` *(fails: workspace linking killed)*
- `cargo test -p the_block persist_temp_file_converts_permission_error -- --nocapture` *(fails: schema_upgrade test imports Tx types and linker killed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4446f9b8832ebb4c8646318713e4