### PR TITLE
Telemetry-Aware Networking and Operational Guidance Enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,17 +94,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -1725,14 +1714,10 @@ dependencies = [
 name = "coding"
 version = "0.1.0"
 dependencies = [
- "chacha20poly1305",
  "rand 0.8.5",
- "raptorq",
- "reed-solomon-erasure",
  "serde",
  "thiserror 1.0.69",
  "toml 0.8.23",
- "zstd 0.12.4",
 ]
 
 [[package]]
@@ -1816,10 +1801,10 @@ dependencies = [
  "bincode",
  "blake3",
  "bridges",
- "chacha20poly1305",
  "clap",
  "clap_complete",
  "codec",
+ "coding",
  "criterion",
  "crypto",
  "crypto_suite",
@@ -2250,7 +2235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2738,6 +2722,7 @@ dependencies = [
  "axum 0.7.9",
  "bincode",
  "blake3",
+ "codec",
  "crypto_suite",
  "hex",
  "lru 0.11.1",
@@ -3378,9 +3363,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3388,7 +3370,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
 ]
 
 [[package]]
@@ -3397,7 +3379,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "allocator-api2",
  "serde",
 ]
@@ -4049,7 +4031,7 @@ version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "indexmap 2.11.1",
  "is-terminal",
  "itoa",
@@ -4608,6 +4590,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "blake3",
+ "coding",
  "core-foundation 0.9.4",
  "crypto_suite",
  "dirs",
@@ -4630,7 +4613,6 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
- "zstd 0.12.4",
 ]
 
 [[package]]
@@ -4696,15 +4678,6 @@ checksum = "eb3e43a8657c1d64516dcc9db8ca03826a4aceaf89d5ce1b37b59f6ff0e43026"
 dependencies = [
  "lazy_static",
  "log",
-]
-
-[[package]]
-name = "lru"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-dependencies = [
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -4860,7 +4833,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "metrics-macros",
  "portable-atomic",
 ]
@@ -4888,8 +4861,7 @@ dependencies = [
  "runtime",
  "serde",
  "serde_json",
- "sled",
- "tempfile",
+ "storage_engine",
  "thiserror 1.0.69",
  "tower 0.5.2",
  "tracing",
@@ -6420,12 +6392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "raptorq"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b1b1fad69672f0b901b5004863ea4307f03d168a3db5f2bcba4d3dfed88e97"
-
-[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6517,19 +6483,6 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "reed-solomon-erasure"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
-dependencies = [
- "libm",
- "lru 0.7.8",
- "parking_lot 0.11.2",
- "smallvec",
- "spin 0.9.8",
 ]
 
 [[package]]
@@ -6673,7 +6626,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin 0.5.2",
+ "spin",
  "untrusted 0.7.1",
  "web-sys",
  "winapi",
@@ -7738,12 +7691,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7819,6 +7766,8 @@ dependencies = [
  "bincode",
  "parking_lot 0.12.4",
  "rocksdb",
+ "serde",
+ "serde_json",
  "sled",
  "tempfile",
  "thiserror 1.0.69",
@@ -8140,7 +8089,6 @@ dependencies = [
  "blake3",
  "bridges",
  "bytes",
- "chacha20poly1305",
  "clap",
  "clap_complete",
  "codec",
@@ -9239,7 +9187,7 @@ version = "0.215.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fbde0881f24199b81cf49b6ff8f9c145ac8eb1b7fc439adb5c099734f7d90e"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bitflags 2.9.4",
  "hashbrown 0.14.5",
  "indexmap 2.11.1",
@@ -10326,15 +10274,6 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe 6.0.6",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
@@ -10347,16 +10286,6 @@ name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Readme
-> **Review (2025-09-29):** Tightened readiness to 98.3/93.3 after re-checking that the aggregator and gateway servers still run on `axum`/`hyper` while `crates/httpd` remains client-only.
+> **Review (2025-09-30):** Documented in-house encryption/compression rollout and refreshed navigation policy pointers.
 > Dependency pivot status: Runtime, transport, overlay, storage_engine, coding, crypto_suite, and codec wrappers are live with governance overrides enforced (2025-09-29).
 ## Table of Contents
 
@@ -21,9 +21,14 @@
 16. [Disclaimer](#disclaimer)
 17. [License](#license)
 
+> **Documentation note:** `docs/book.toml` sets `src = "."`, so `docs/SUMMARY.md`
+> remains the single canonical table of contents. Keep the repository root free
+> of a duplicate `SUMMARY.md`; mdBook will compile correctly as long as the
+> `docs/` tree stays in sync.
+
 ---
 
-> **Review (2025-09-29):** Tightened readiness to 98.3/93.3 after re-checking that the aggregator and gateway servers still run on `axum`/`hyper` while `crates/httpd` remains client-only.
+> **Review (2025-09-30):** Highlighted overlay peer-store migrator across operator release docs.
 
 ## What is The Block?
 
@@ -132,7 +137,7 @@ test real services today.
         `p2p_overlay` crate with selectable in-house/stub backends, CLI overrides,
         telemetry gauges, and integration tests, so node modules only depend on overlay traits. Base58-check peer IDs are surfaced end-to-end, CLI gossip introspection prints the most recent fanout set in base58, and shard-aware peer maps route block gossip only
         to interested peers and uptime-based fee rebates reward high-availability
-        peers. (98.1% Complete)
+        peers. Operator release notes and operator runbooks now call out the bundled `migrate_overlay_store` helper—see [`docs/governance_release.md`](docs/governance_release.md) and [`docs/operators/run_a_node.md`](docs/operators/run_a_node.md#migrating-overlay-peer-stores)—so peer databases can be upgraded without manual edits. (98.1% Complete)
       - Hybrid proof-of-work and proof-of-stake consensus schedules leaders by stake,
         resolves forks deterministically, and validates blocks with BLAKE3 hashes,
         multi-window Kalman retargeting, VDF-anchored randomness, macro-block
@@ -313,7 +318,7 @@ Mainnet readiness sits at **98.3/100** with vision completion **93.3/100**.
   before clients honor them. See [docs/gateway_dns.md](docs/gateway_dns.md).
 - Durable compute courier records bundles with exponential backoff retries; see [docs/compute_market_courier.md](docs/compute_market_courier.md).
 - Macro-block checkpoints capture per-shard roots and inter-shard queue proofs for cross-shard ordering; see [docs/macro_block.md](docs/macro_block.md).
-- Real-time state streaming over WebSockets keeps light clients current with zstd-compressed snapshots; see [docs/light_client_stream.md](docs/light_client_stream.md).
+- Real-time state streaming over WebSockets keeps light clients current with hybrid-compressed (lz77-rle) snapshots; see [docs/light_client_stream.md](docs/light_client_stream.md).
 - SNARK-verified compute receipts tie payments to Groth16 proofs generated from small WASM tasks; see [docs/compute_snarks.md](docs/compute_snarks.md).
 - Reputation-weighted, Lagrange-coded storage allocation with proof-of-retrievability challenges; see [docs/storage_market.md](docs/storage_market.md).
 - Constant-product AMM pools with epoch-based liquidity mining incentives; see [docs/dex_amm.md](docs/dex_amm.md).

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,13 +32,13 @@ wasmtime = { version = "24", optional = true }
 blake3 = "1"
 base64 = "0.22"
 rusqlite = { version = "0.30", features = ["bundled"], optional = true }
-chacha20poly1305 = "0.10"
 rpassword = "7"
 rand = "0.8"
 once_cell = "1"
 state = { path = "../state" }
 dirs = "5"
 httpd = { path = "../crates/httpd" }
+coding = { path = "../crates/coding" }
 
 [features]
 default = []

--- a/config/dependency_policies.toml
+++ b/config/dependency_policies.toml
@@ -17,9 +17,6 @@ replaceable = [
   "rocksdb",
   "serde",
   "bincode",
-  "zstd",
-  "reed-solomon",
-  "raptorq",
 ]
 forbidden = [
 ]

--- a/config/storage.toml
+++ b/config/storage.toml
@@ -8,12 +8,12 @@ data_shards = 16
 parity_shards = 8
 
 [fountain]
-algorithm = "raptorq"
+algorithm = "lt-inhouse"
 symbol_size = 1024
 rate = 1.2
 
 [compression]
-algorithm = "zstd"
+algorithm = "lz77-rle"
 # Set to `"rle"` to use the lightweight run-length fallback compressor.
 level = 0
 

--- a/crates/coding/Cargo.toml
+++ b/crates/coding/Cargo.toml
@@ -4,11 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chacha20poly1305 = { version = "0.10", features = ["rand_core"] }
 rand = { version = "0.8", features = ["std"] }
-reed-solomon-erasure = "6"
-raptorq = "2"
 thiserror = "1"
-zstd = "0.12"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"

--- a/crates/coding/src/compression/inhouse.rs
+++ b/crates/coding/src/compression/inhouse.rs
@@ -1,0 +1,333 @@
+use crate::error::CompressionError;
+
+const MAX_LITERAL: usize = 128;
+const MIN_MATCH: usize = 3;
+const MAX_MATCH: usize = 130;
+const TOKEN_MATCH: u8 = 0x80;
+
+#[derive(Clone, Debug)]
+pub struct HybridCompressor {
+    window_size: usize,
+    search_span: usize,
+}
+
+impl HybridCompressor {
+    pub fn new(level: i32) -> Self {
+        let clamped = level.clamp(0, 9) as usize;
+        let window_size = 4096 + clamped * 1024;
+        let search_span = (64 + clamped * 32).min(window_size);
+        Self {
+            window_size,
+            search_span,
+        }
+    }
+
+    pub fn stream_encoder(&self) -> HybridEncoder {
+        HybridEncoder::new(self.window_size, self.search_span)
+    }
+
+    pub fn stream_decoder(&self) -> HybridDecoder {
+        HybridDecoder::new(self.window_size)
+    }
+
+    pub fn compress(&self, data: &[u8]) -> Result<Vec<u8>, CompressionError> {
+        let mut encoder = self.stream_encoder();
+        let mut out = Vec::with_capacity(data.len());
+        encoder.push(data, &mut out)?;
+        encoder.finish(&mut out)?;
+        Ok(out)
+    }
+
+    pub fn decompress(&self, data: &[u8]) -> Result<Vec<u8>, CompressionError> {
+        let mut decoder = self.stream_decoder();
+        let mut out = Vec::with_capacity(data.len() * 2 + 1);
+        decoder.push(data, &mut out)?;
+        decoder.finish()?;
+        Ok(out)
+    }
+}
+
+pub struct HybridEncoder {
+    window: Vec<u8>,
+    buffer: Vec<u8>,
+    literals: Vec<u8>,
+    window_size: usize,
+    search_span: usize,
+}
+
+impl HybridEncoder {
+    fn new(window_size: usize, search_span: usize) -> Self {
+        Self {
+            window: Vec::with_capacity(window_size),
+            buffer: Vec::new(),
+            literals: Vec::new(),
+            window_size,
+            search_span,
+        }
+    }
+
+    pub fn push(&mut self, chunk: &[u8], out: &mut Vec<u8>) -> Result<(), CompressionError> {
+        self.buffer.extend_from_slice(chunk);
+        let mut index = 0usize;
+        let limit = self
+            .buffer
+            .len()
+            .saturating_sub(MAX_MATCH)
+            .min(self.buffer.len());
+        while index < limit {
+            if let Some((offset, len)) = self.find_match(index) {
+                let slice = self.buffer[index..index + len].to_vec();
+                self.flush_literals(out);
+                self.emit_match(out, offset, len);
+                self.extend_window(&slice);
+                index += len;
+            } else {
+                let byte = self.buffer[index];
+                self.literals.push(byte);
+                if self.literals.len() == MAX_LITERAL {
+                    self.flush_literals(out);
+                }
+                self.extend_window(&[byte]);
+                index += 1;
+            }
+        }
+        if index > 0 {
+            self.buffer.drain(0..index);
+        }
+        Ok(())
+    }
+
+    pub fn finish(&mut self, out: &mut Vec<u8>) -> Result<(), CompressionError> {
+        let mut index = 0usize;
+        while index < self.buffer.len() {
+            if let Some((offset, len)) = self.find_match(index) {
+                let slice = self.buffer[index..index + len].to_vec();
+                self.flush_literals(out);
+                self.emit_match(out, offset, len);
+                self.extend_window(&slice);
+                index += len;
+            } else {
+                let byte = self.buffer[index];
+                self.literals.push(byte);
+                if self.literals.len() == MAX_LITERAL {
+                    self.flush_literals(out);
+                }
+                self.extend_window(&[byte]);
+                index += 1;
+            }
+        }
+        self.flush_literals(out);
+        self.buffer.clear();
+        Ok(())
+    }
+
+    fn find_match(&self, start: usize) -> Option<(usize, usize)> {
+        if start >= self.buffer.len() || self.window.len() < MIN_MATCH {
+            return None;
+        }
+        let lookahead = &self.buffer[start..];
+        if lookahead.len() < MIN_MATCH {
+            return None;
+        }
+        let max_len = lookahead.len().min(MAX_MATCH);
+        let window_len = self.window.len();
+        let span = self.search_span.min(window_len);
+        let mut best_len = 0usize;
+        let mut best_offset = 0usize;
+        for offset in 1..=span {
+            let window_start = window_len - offset;
+            if self.window[window_start] != lookahead[0] {
+                continue;
+            }
+            let mut length = 1usize;
+            while length < max_len && window_start + length < window_len {
+                if self.window[window_start + length] != lookahead[length] {
+                    break;
+                }
+                length += 1;
+            }
+            if length >= MIN_MATCH && length > best_len {
+                best_len = length;
+                best_offset = offset;
+                if best_len == max_len {
+                    break;
+                }
+            }
+        }
+        if best_len >= MIN_MATCH {
+            Some((best_offset, best_len))
+        } else {
+            None
+        }
+    }
+
+    fn emit_match(&self, out: &mut Vec<u8>, offset: usize, len: usize) {
+        let len_byte = (len - MIN_MATCH) as u8 & 0x7F;
+        out.push(TOKEN_MATCH | len_byte);
+        out.extend_from_slice(&(offset as u16).to_le_bytes());
+    }
+
+    fn flush_literals(&mut self, out: &mut Vec<u8>) {
+        if self.literals.is_empty() {
+            return;
+        }
+        let mut cursor = 0usize;
+        while cursor < self.literals.len() {
+            let take = (self.literals.len() - cursor).min(MAX_LITERAL);
+            out.push((take - 1) as u8);
+            out.extend_from_slice(&self.literals[cursor..cursor + take]);
+            cursor += take;
+        }
+        self.literals.clear();
+    }
+
+    fn extend_window(&mut self, data: &[u8]) {
+        self.window.extend_from_slice(data);
+        if self.window.len() > self.window_size {
+            let excess = self.window.len() - self.window_size;
+            self.window.drain(0..excess);
+        }
+    }
+}
+
+pub struct HybridDecoder {
+    window: Vec<u8>,
+    pending: Vec<u8>,
+    window_size: usize,
+}
+
+impl HybridDecoder {
+    fn new(window_size: usize) -> Self {
+        Self {
+            window: Vec::with_capacity(window_size),
+            pending: Vec::new(),
+            window_size,
+        }
+    }
+
+    pub fn push(&mut self, chunk: &[u8], out: &mut Vec<u8>) -> Result<(), CompressionError> {
+        self.pending.extend_from_slice(chunk);
+        let mut index = 0usize;
+        while index < self.pending.len() {
+            let token = self.pending[index];
+            if token & TOKEN_MATCH == 0 {
+                let literal_len = (token as usize) + 1;
+                if self.pending.len() < index + 1 + literal_len {
+                    break;
+                }
+                let start = index + 1;
+                let end = start + literal_len;
+                let segment = self.pending[start..end].to_vec();
+                out.extend_from_slice(&segment);
+                self.extend_window(&segment);
+                index = end;
+            } else {
+                if self.pending.len() < index + 3 {
+                    break;
+                }
+                let len = (token as usize & 0x7F) + MIN_MATCH;
+                let offset =
+                    u16::from_le_bytes([self.pending[index + 1], self.pending[index + 2]]) as usize;
+                if offset == 0 {
+                    return Err(CompressionError::Decompress("lz77 offset zero".into()));
+                }
+                if offset > out.len() {
+                    return Err(CompressionError::Decompress(
+                        "lz77 offset out of range".into(),
+                    ));
+                }
+                for _ in 0..len {
+                    let src_index = out.len() - offset;
+                    let byte = out[src_index];
+                    out.push(byte);
+                    self.extend_window(&[byte]);
+                }
+                index += 3;
+            }
+        }
+        if index > 0 {
+            self.pending.drain(0..index);
+        }
+        Ok(())
+    }
+
+    pub fn finish(&mut self) -> Result<(), CompressionError> {
+        if !self.pending.is_empty() {
+            return Err(CompressionError::Decompress(
+                "hybrid payload truncated".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn extend_window(&mut self, data: &[u8]) {
+        self.window.extend_from_slice(data);
+        if self.window.len() > self.window_size {
+            let excess = self.window.len() - self.window_size;
+            self.window.drain(0..excess);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_small() {
+        let compressor = HybridCompressor::new(3);
+        let data = b"aaaaabbbbccccccccccdddddddddddd";
+        let encoded = compressor.compress(data).unwrap();
+        let decoded = compressor.decompress(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn round_trip_random() {
+        let compressor = HybridCompressor::new(6);
+        let mut data = vec![0u8; 4096];
+        for (i, byte) in data.iter_mut().enumerate() {
+            *byte = ((i * 31) ^ (i >> 3)) as u8;
+        }
+        let encoded = compressor.compress(&data).unwrap();
+        let decoded = compressor.decompress(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn streaming_round_trip() {
+        let compressor = HybridCompressor::new(4);
+        let mut encoder = compressor.stream_encoder();
+        let mut encoded = Vec::new();
+        for chunk in [b"hello ".as_ref(), b"world".as_ref(), b"!".as_ref()] {
+            encoder.push(chunk, &mut encoded).unwrap();
+        }
+        encoder.finish(&mut encoded).unwrap();
+
+        let mut decoder = compressor.stream_decoder();
+        let mut decoded = Vec::new();
+        for chunk in encoded.chunks(3) {
+            decoder.push(chunk, &mut decoded).unwrap();
+        }
+        decoder.finish().unwrap();
+        assert_eq!(decoded, b"hello world!");
+    }
+
+    #[test]
+    fn detect_truncated_payload() {
+        let compressor = HybridCompressor::new(2);
+        let mut encoder = compressor.stream_encoder();
+        let mut encoded = Vec::new();
+        encoder.push(b"sample", &mut encoded).unwrap();
+        encoder.finish(&mut encoded).unwrap();
+        let mut decoder = compressor.stream_decoder();
+        let mut output = Vec::new();
+        decoder
+            .push(&encoded[..encoded.len() - 1], &mut output)
+            .expect("accepts partial chunk");
+        assert!(matches!(
+            decoder.finish(),
+            Err(CompressionError::Decompress(_))
+        ));
+    }
+}

--- a/crates/coding/src/config.rs
+++ b/crates/coding/src/config.rs
@@ -178,7 +178,7 @@ fn default_parity_shards() -> usize {
 }
 
 fn default_fountain_algorithm() -> String {
-    "raptorq".to_string()
+    "lt-inhouse".to_string()
 }
 
 fn default_symbol_size() -> u16 {
@@ -190,7 +190,7 @@ fn default_fountain_rate() -> f32 {
 }
 
 fn default_compression_algorithm() -> String {
-    "zstd".to_string()
+    "lz77-rle".to_string()
 }
 
 fn default_compression_level() -> i32 {

--- a/crates/coding/src/encrypt/inhouse.rs
+++ b/crates/coding/src/encrypt/inhouse.rs
@@ -1,0 +1,548 @@
+use crate::error::EncryptError;
+use core::num::Wrapping;
+use rand::{rngs::OsRng, RngCore};
+
+pub const KEY_LEN: usize = 32;
+pub const NONCE_LEN: usize = 12;
+pub const TAG_LEN: usize = 16;
+pub const XNONCE_LEN: usize = 24;
+const BLOCK_WORDS: usize = 16;
+const BLOCK_BYTES: usize = 64;
+
+#[inline(always)]
+fn rotate_left(v: u32, n: u32) -> u32 {
+    v.rotate_left(n)
+}
+
+#[inline(always)]
+fn quarter_round(state: &mut [u32; BLOCK_WORDS], a: usize, b: usize, c: usize, d: usize) {
+    state[a] = state[a].wrapping_add(state[b]);
+    state[d] ^= state[a];
+    state[d] = rotate_left(state[d], 16);
+
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] ^= state[c];
+    state[b] = rotate_left(state[b], 12);
+
+    state[a] = state[a].wrapping_add(state[b]);
+    state[d] ^= state[a];
+    state[d] = rotate_left(state[d], 8);
+
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] ^= state[c];
+    state[b] = rotate_left(state[b], 7);
+}
+
+fn chacha20_block(key: &[u8; KEY_LEN], counter: u32, nonce: &[u8; NONCE_LEN]) -> [u8; BLOCK_BYTES] {
+    let mut state = [0u32; BLOCK_WORDS];
+    state[0] = 0x6170_7865;
+    state[1] = 0x3320_646e;
+    state[2] = 0x7962_2d32;
+    state[3] = 0x6b20_6574;
+
+    for (i, chunk) in key.chunks_exact(4).enumerate() {
+        state[4 + i] = u32::from_le_bytes(chunk.try_into().unwrap());
+    }
+
+    state[12] = counter;
+    state[13] = u32::from_le_bytes(nonce[0..4].try_into().unwrap());
+    state[14] = u32::from_le_bytes(nonce[4..8].try_into().unwrap());
+    state[15] = u32::from_le_bytes(nonce[8..12].try_into().unwrap());
+
+    let mut working = state;
+    for _ in 0..10 {
+        quarter_round(&mut working, 0, 4, 8, 12);
+        quarter_round(&mut working, 1, 5, 9, 13);
+        quarter_round(&mut working, 2, 6, 10, 14);
+        quarter_round(&mut working, 3, 7, 11, 15);
+        quarter_round(&mut working, 0, 5, 10, 15);
+        quarter_round(&mut working, 1, 6, 11, 12);
+        quarter_round(&mut working, 2, 7, 8, 13);
+        quarter_round(&mut working, 3, 4, 9, 14);
+    }
+
+    for i in 0..BLOCK_WORDS {
+        working[i] = working[i].wrapping_add(state[i]);
+    }
+
+    let mut out = [0u8; BLOCK_BYTES];
+    for (i, word) in working.iter().enumerate() {
+        out[i * 4..(i + 1) * 4].copy_from_slice(&word.to_le_bytes());
+    }
+    out
+}
+
+fn hchacha20(key: &[u8; KEY_LEN], nonce: &[u8; 16]) -> [u8; KEY_LEN] {
+    let mut state = [0u32; BLOCK_WORDS];
+    state[0] = 0x6170_7865;
+    state[1] = 0x3320_646e;
+    state[2] = 0x7962_2d32;
+    state[3] = 0x6b20_6574;
+
+    for (i, chunk) in key.chunks_exact(4).enumerate() {
+        state[4 + i] = u32::from_le_bytes(chunk.try_into().unwrap());
+    }
+
+    for (i, chunk) in nonce.chunks_exact(4).enumerate() {
+        state[12 + i] = u32::from_le_bytes(chunk.try_into().unwrap());
+    }
+
+    let mut working = state;
+    for _ in 0..10 {
+        quarter_round(&mut working, 0, 4, 8, 12);
+        quarter_round(&mut working, 1, 5, 9, 13);
+        quarter_round(&mut working, 2, 6, 10, 14);
+        quarter_round(&mut working, 3, 7, 11, 15);
+        quarter_round(&mut working, 0, 5, 10, 15);
+        quarter_round(&mut working, 1, 6, 11, 12);
+        quarter_round(&mut working, 2, 7, 8, 13);
+        quarter_round(&mut working, 3, 4, 9, 14);
+    }
+
+    let mut out = [0u8; KEY_LEN];
+    let words = [
+        working[0],
+        working[1],
+        working[2],
+        working[3],
+        working[12],
+        working[13],
+        working[14],
+        working[15],
+    ];
+    for (i, word) in words.iter().enumerate() {
+        out[i * 4..(i + 1) * 4].copy_from_slice(&word.to_le_bytes());
+    }
+    out
+}
+
+fn derive_xchacha_params(
+    key: &[u8; KEY_LEN],
+    nonce: &[u8; XNONCE_LEN],
+) -> ([u8; KEY_LEN], [u8; NONCE_LEN]) {
+    let mut nonce16 = [0u8; 16];
+    nonce16.copy_from_slice(&nonce[..16]);
+    let derived_key = hchacha20(key, &nonce16);
+
+    let mut derived_nonce = [0u8; NONCE_LEN];
+    derived_nonce[4..].copy_from_slice(&nonce[16..]);
+    (derived_key, derived_nonce)
+}
+
+#[inline(always)]
+fn clamp_r(mut r: [u8; 16]) -> [u8; 16] {
+    r[3] &= 15;
+    r[7] &= 15;
+    r[11] &= 15;
+    r[15] &= 15;
+    r[4] &= 252;
+    r[8] &= 252;
+    r[12] &= 252;
+    r
+}
+
+fn load32(input: &[u8], offset: usize) -> u32 {
+    let mut buf = [0u8; 4];
+    buf.copy_from_slice(&input[offset..offset + 4]);
+    u32::from_le_bytes(buf)
+}
+
+fn decode_block(block: &[u8; 16], full: bool) -> [u128; 5] {
+    const MASK: u128 = (1 << 26) - 1;
+    let t0 = u128::from(load32(block, 0)) & MASK;
+    let t1 = (u128::from(load32(block, 3)) >> 2) & MASK;
+    let t2 = (u128::from(load32(block, 6)) >> 4) & MASK;
+    let t3 = (u128::from(load32(block, 9)) >> 6) & MASK;
+    let mut t4 = (u128::from(load32(block, 12)) >> 8) & MASK;
+    if full {
+        t4 |= 1 << 24;
+    }
+    [t0, t1, t2, t3, t4]
+}
+
+fn poly1305_accumulate(r: &[u8; 16], s: &[u8; 16], msg: &[u8]) -> [u8; 16] {
+    const MASK: u128 = (1 << 26) - 1;
+
+    let r_limbs_full = decode_block(r, false);
+    let r0 = r_limbs_full[0];
+    let r1 = r_limbs_full[1];
+    let r2 = r_limbs_full[2];
+    let r3 = r_limbs_full[3];
+    let r4 = r_limbs_full[4];
+
+    let r1_5 = r1 * 5;
+    let r2_5 = r2 * 5;
+    let r3_5 = r3 * 5;
+    let r4_5 = r4 * 5;
+
+    let mut h0 = 0u128;
+    let mut h1 = 0u128;
+    let mut h2 = 0u128;
+    let mut h3 = 0u128;
+    let mut h4 = 0u128;
+
+    let mut chunks = msg.chunks_exact(16);
+    for block in &mut chunks {
+        let block_arr: [u8; 16] = block.try_into().unwrap();
+        let limbs = decode_block(&block_arr, true);
+        h0 += limbs[0];
+        h1 += limbs[1];
+        h2 += limbs[2];
+        h3 += limbs[3];
+        h4 += limbs[4];
+
+        let d0 = h0 * r0 + h1 * r4_5 + h2 * r3_5 + h3 * r2_5 + h4 * r1_5;
+        let mut d1 = h0 * r1 + h1 * r0 + h2 * r4_5 + h3 * r3_5 + h4 * r2_5;
+        let mut d2 = h0 * r2 + h1 * r1 + h2 * r0 + h3 * r4_5 + h4 * r3_5;
+        let mut d3 = h0 * r3 + h1 * r2 + h2 * r1 + h3 * r0 + h4 * r4_5;
+        let mut d4 = h0 * r4 + h1 * r3 + h2 * r2 + h3 * r1 + h4 * r0;
+
+        let mut carry = d0 >> 26;
+        h0 = d0 & MASK;
+        d1 += carry;
+
+        carry = d1 >> 26;
+        h1 = d1 & MASK;
+        d2 += carry;
+
+        carry = d2 >> 26;
+        h2 = d2 & MASK;
+        d3 += carry;
+
+        carry = d3 >> 26;
+        h3 = d3 & MASK;
+        d4 += carry;
+
+        carry = d4 >> 26;
+        h4 = d4 & MASK;
+        h0 += carry * 5;
+
+        carry = h0 >> 26;
+        h0 &= MASK;
+        h1 += carry;
+    }
+
+    let remainder = chunks.remainder();
+    if !remainder.is_empty() {
+        let mut block = [0u8; 16];
+        block[..remainder.len()].copy_from_slice(remainder);
+        block[remainder.len()] = 1;
+        let limbs = decode_block(&block, false);
+        h0 += limbs[0];
+        h1 += limbs[1];
+        h2 += limbs[2];
+        h3 += limbs[3];
+        h4 += limbs[4];
+
+        let d0 = h0 * r0 + h1 * r4_5 + h2 * r3_5 + h3 * r2_5 + h4 * r1_5;
+        let mut d1 = h0 * r1 + h1 * r0 + h2 * r4_5 + h3 * r3_5 + h4 * r2_5;
+        let mut d2 = h0 * r2 + h1 * r1 + h2 * r0 + h3 * r4_5 + h4 * r3_5;
+        let mut d3 = h0 * r3 + h1 * r2 + h2 * r1 + h3 * r0 + h4 * r4_5;
+        let mut d4 = h0 * r4 + h1 * r3 + h2 * r2 + h3 * r1 + h4 * r0;
+
+        let mut carry = d0 >> 26;
+        h0 = d0 & MASK;
+        d1 += carry;
+
+        carry = d1 >> 26;
+        h1 = d1 & MASK;
+        d2 += carry;
+
+        carry = d2 >> 26;
+        h2 = d2 & MASK;
+        d3 += carry;
+
+        carry = d3 >> 26;
+        h3 = d3 & MASK;
+        d4 += carry;
+
+        carry = d4 >> 26;
+        h4 = d4 & MASK;
+        h0 += carry * 5;
+
+        carry = h0 >> 26;
+        h0 &= MASK;
+        h1 += carry;
+    }
+
+    let mut lengths = [0u8; 16];
+    lengths[8..].copy_from_slice(&(msg.len() as u64).to_le_bytes());
+    let limbs = decode_block(&lengths, true);
+    h0 += limbs[0];
+    h1 += limbs[1];
+    h2 += limbs[2];
+    h3 += limbs[3];
+    h4 += limbs[4];
+
+    let d0 = h0 * r0 + h1 * r4_5 + h2 * r3_5 + h3 * r2_5 + h4 * r1_5;
+    let mut d1 = h0 * r1 + h1 * r0 + h2 * r4_5 + h3 * r3_5 + h4 * r2_5;
+    let mut d2 = h0 * r2 + h1 * r1 + h2 * r0 + h3 * r4_5 + h4 * r3_5;
+    let mut d3 = h0 * r3 + h1 * r2 + h2 * r1 + h3 * r0 + h4 * r4_5;
+    let mut d4 = h0 * r4 + h1 * r3 + h2 * r2 + h3 * r1 + h4 * r0;
+
+    let mut carry = d0 >> 26;
+    h0 = d0 & MASK;
+    d1 += carry;
+
+    carry = d1 >> 26;
+    h1 = d1 & MASK;
+    d2 += carry;
+
+    carry = d2 >> 26;
+    h2 = d2 & MASK;
+    d3 += carry;
+
+    carry = d3 >> 26;
+    h3 = d3 & MASK;
+    d4 += carry;
+
+    carry = d4 >> 26;
+    h4 = d4 & MASK;
+    h0 += carry * 5;
+
+    carry = h0 >> 26;
+    h0 &= MASK;
+    h1 += carry;
+
+    carry = h1 >> 26;
+    h1 &= MASK;
+    h2 += carry;
+
+    carry = h2 >> 26;
+    h2 &= MASK;
+    h3 += carry;
+
+    carry = h3 >> 26;
+    h3 &= MASK;
+    h4 += carry;
+
+    carry = h4 >> 26;
+    h4 &= MASK;
+    h0 += carry * 5;
+
+    carry = h0 >> 26;
+    h0 &= MASK;
+    h1 += carry;
+
+    carry = h1 >> 26;
+    h1 &= MASK;
+    h2 += carry;
+
+    carry = h2 >> 26;
+    h2 &= MASK;
+    h3 += carry;
+
+    carry = h3 >> 26;
+    h3 &= MASK;
+    h4 += carry;
+    h4 &= MASK;
+
+    let mut g0 = h0 + 5;
+    carry = g0 >> 26;
+    g0 &= MASK;
+    let mut g1 = h1 + carry;
+    carry = g1 >> 26;
+    g1 &= MASK;
+    let mut g2 = h2 + carry;
+    carry = g2 >> 26;
+    g2 &= MASK;
+    let mut g3 = h3 + carry;
+    carry = g3 >> 26;
+    g3 &= MASK;
+    let g4 = (h4 + carry) as i128 - (1 << 26);
+
+    let mask = (g4 >> 63) as i128;
+    let not_mask = !mask;
+
+    let h0_i = h0 as i128;
+    let h1_i = h1 as i128;
+    let h2_i = h2 as i128;
+    let h3_i = h3 as i128;
+    let h4_i = h4 as i128;
+
+    let g0_i = g0 as i128;
+    let g1_i = g1 as i128;
+    let g2_i = g2 as i128;
+    let g3_i = g3 as i128;
+
+    let f0 = ((g0_i & not_mask) | (h0_i & mask)) as u128;
+    let f1 = ((g1_i & not_mask) | (h1_i & mask)) as u128;
+    let f2 = ((g2_i & not_mask) | (h2_i & mask)) as u128;
+    let f3 = ((g3_i & not_mask) | (h3_i & mask)) as u128;
+    let f4 = (((g4 + (1 << 26)) & not_mask) | (h4_i & mask)) as u128;
+
+    let tag_base = Wrapping(f0)
+        + Wrapping(f1 << 26)
+        + Wrapping(f2 << 52)
+        + Wrapping(f3 << 78)
+        + Wrapping(f4 << 104);
+
+    let s_val = Wrapping(u128::from_le_bytes(*s));
+    let tag = (tag_base + s_val).0;
+    tag.to_le_bytes()
+}
+
+fn compute_poly1305_key(key: &[u8; KEY_LEN], nonce: &[u8; NONCE_LEN]) -> ([u8; 16], [u8; 16]) {
+    let block = chacha20_block(key, 0, nonce);
+    let mut r = [0u8; 16];
+    let mut s = [0u8; 16];
+    r.copy_from_slice(&block[0..16]);
+    s.copy_from_slice(&block[16..32]);
+    (clamp_r(r), s)
+}
+
+fn chacha20_apply(
+    key: &[u8; KEY_LEN],
+    nonce: &[u8; NONCE_LEN],
+    counter: u32,
+    data: &[u8],
+) -> Vec<u8> {
+    let mut output = Vec::with_capacity(data.len());
+    let mut ctr = counter;
+    let mut offset = 0usize;
+    while offset < data.len() {
+        let block = chacha20_block(key, ctr, nonce);
+        ctr = ctr.wrapping_add(1);
+        let take = (data.len() - offset).min(BLOCK_BYTES);
+        for i in 0..take {
+            output.push(data[offset + i] ^ block[i]);
+        }
+        offset += take;
+    }
+    output
+}
+
+fn constant_time_eq(a: &[u8; TAG_LEN], b: &[u8; TAG_LEN]) -> bool {
+    let mut diff = 0u8;
+    for i in 0..TAG_LEN {
+        diff |= a[i] ^ b[i];
+    }
+    diff == 0
+}
+
+fn seal_with_nonce(
+    key: &[u8; KEY_LEN],
+    nonce: &[u8; NONCE_LEN],
+    plaintext: &[u8],
+) -> Result<Vec<u8>, EncryptError> {
+    let (r, s) = compute_poly1305_key(key, nonce);
+    let ciphertext = chacha20_apply(key, nonce, 1, plaintext);
+    let tag = poly1305_accumulate(&r, &s, &ciphertext);
+
+    let mut out = Vec::with_capacity(NONCE_LEN + ciphertext.len() + TAG_LEN);
+    out.extend_from_slice(nonce);
+    out.extend_from_slice(&ciphertext);
+    out.extend_from_slice(&tag);
+    Ok(out)
+}
+
+pub fn encrypt(key: &[u8; KEY_LEN], plaintext: &[u8]) -> Result<Vec<u8>, EncryptError> {
+    let mut nonce = [0u8; NONCE_LEN];
+    OsRng.fill_bytes(&mut nonce);
+    seal_with_nonce(key, &nonce, plaintext)
+}
+
+pub fn decrypt(key: &[u8; KEY_LEN], payload: &[u8]) -> Result<Vec<u8>, EncryptError> {
+    if payload.len() < NONCE_LEN + TAG_LEN {
+        return Err(EncryptError::InvalidCiphertext { len: payload.len() });
+    }
+    let (nonce_bytes, rest) = payload.split_at(NONCE_LEN);
+    let (ciphertext, tag_bytes) = rest.split_at(rest.len() - TAG_LEN);
+    let mut nonce = [0u8; NONCE_LEN];
+    nonce.copy_from_slice(nonce_bytes);
+    let mut tag = [0u8; TAG_LEN];
+    tag.copy_from_slice(tag_bytes);
+
+    let (r, s) = compute_poly1305_key(key, &nonce);
+    let expected = poly1305_accumulate(&r, &s, ciphertext);
+    if !constant_time_eq(&expected, &tag) {
+        return Err(EncryptError::DecryptionFailed);
+    }
+    Ok(chacha20_apply(key, &nonce, 1, ciphertext))
+}
+
+fn seal_xchacha_with_nonce(
+    key: &[u8; KEY_LEN],
+    nonce: &[u8; XNONCE_LEN],
+    plaintext: &[u8],
+) -> Result<Vec<u8>, EncryptError> {
+    let (derived_key, derived_nonce) = derive_xchacha_params(key, nonce);
+    let inner = seal_with_nonce(&derived_key, &derived_nonce, plaintext)?;
+    let mut out = Vec::with_capacity(XNONCE_LEN + inner.len().saturating_sub(NONCE_LEN));
+    out.extend_from_slice(nonce);
+    out.extend_from_slice(&inner[NONCE_LEN..]);
+    Ok(out)
+}
+
+pub fn encrypt_xchacha(key: &[u8; KEY_LEN], plaintext: &[u8]) -> Result<Vec<u8>, EncryptError> {
+    let mut nonce = [0u8; XNONCE_LEN];
+    OsRng.fill_bytes(&mut nonce);
+    seal_xchacha_with_nonce(key, &nonce, plaintext)
+}
+
+pub fn encrypt_xchacha_with_nonce(
+    key: &[u8; KEY_LEN],
+    nonce: &[u8; XNONCE_LEN],
+    plaintext: &[u8],
+) -> Result<Vec<u8>, EncryptError> {
+    seal_xchacha_with_nonce(key, nonce, plaintext)
+}
+
+pub fn decrypt_xchacha(key: &[u8; KEY_LEN], payload: &[u8]) -> Result<Vec<u8>, EncryptError> {
+    if payload.len() < XNONCE_LEN + TAG_LEN {
+        return Err(EncryptError::InvalidCiphertext { len: payload.len() });
+    }
+    let mut nonce = [0u8; XNONCE_LEN];
+    nonce.copy_from_slice(&payload[..XNONCE_LEN]);
+    let (derived_key, derived_nonce) = derive_xchacha_params(key, &nonce);
+    let mut combined = Vec::with_capacity(NONCE_LEN + payload.len() - XNONCE_LEN);
+    combined.extend_from_slice(&derived_nonce);
+    combined.extend_from_slice(&payload[XNONCE_LEN..]);
+    decrypt(&derived_key, &combined)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let key = [7u8; KEY_LEN];
+        let plaintext = b"test message with enough length to span blocks";
+        let cipher = encrypt(&key, plaintext).unwrap();
+        let plain = decrypt(&key, &cipher).unwrap();
+        assert_eq!(plain, plaintext);
+    }
+
+    #[test]
+    fn rfc_vector() {
+        let key: [u8; KEY_LEN] = [
+            0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d,
+            0x8e, 0x8f, 0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b,
+            0x9c, 0x9d, 0x9e, 0x9f,
+        ];
+        let nonce = [
+            0x07, 0x00, 0x00, 0x00, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
+        ];
+        let mut plaintext = vec![0u8; 114];
+        for (i, b) in plaintext.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        let cipher = seal_with_nonce(&key, &nonce, &plaintext).unwrap();
+        assert_eq!(&cipher[..NONCE_LEN], &nonce);
+        let plain = decrypt(&key, &cipher).unwrap();
+        assert_eq!(plain, plaintext);
+    }
+
+    #[test]
+    fn tamper_detected() {
+        let key = [42u8; KEY_LEN];
+        let plaintext = b"short";
+        let mut cipher = encrypt(&key, plaintext).unwrap();
+        cipher[NONCE_LEN] ^= 0x01;
+        assert!(matches!(
+            decrypt(&key, &cipher),
+            Err(EncryptError::DecryptionFailed)
+        ));
+    }
+}

--- a/crates/coding/src/erasure/inhouse.rs
+++ b/crates/coding/src/erasure/inhouse.rs
@@ -1,0 +1,360 @@
+use super::{
+    ErasureBatch, ErasureCoder, ErasureError, ErasureMetadata, ErasureShard, ErasureShardKind,
+};
+
+const PRIMITIVE_POLY: u8 = 0x1d;
+const FIELD_SIZE: usize = 256;
+const FIELD_ORDER: usize = FIELD_SIZE - 1;
+
+#[derive(Clone)]
+struct GfTables {
+    exp: [u8; FIELD_SIZE * 2],
+    log: [u8; FIELD_SIZE],
+}
+
+impl GfTables {
+    const fn build() -> Self {
+        let mut exp = [0u8; FIELD_SIZE * 2];
+        let mut log = [0u8; FIELD_SIZE];
+        let mut value: u8 = 1;
+        let mut i = 0usize;
+        while i < FIELD_ORDER {
+            exp[i] = value;
+            log[value as usize] = i as u8;
+            value = mul_no_tables(value, 2);
+            i += 1;
+        }
+        let mut j = FIELD_ORDER;
+        while j < exp.len() {
+            exp[j] = exp[j - FIELD_ORDER];
+            j += 1;
+        }
+        Self { exp, log }
+    }
+}
+
+const TABLES: GfTables = GfTables::build();
+
+const fn mul_no_tables(mut a: u8, mut b: u8) -> u8 {
+    let mut product: u8 = 0;
+    let mut i = 0;
+    while i < 8 {
+        if (b & 1) != 0 {
+            product ^= a;
+        }
+        let carry = a & 0x80;
+        a <<= 1;
+        if carry != 0 {
+            a ^= PRIMITIVE_POLY;
+        }
+        b >>= 1;
+        i += 1;
+    }
+    product
+}
+
+#[inline]
+fn gf_add(a: u8, b: u8) -> u8 {
+    a ^ b
+}
+
+#[inline]
+fn gf_mul(a: u8, b: u8) -> u8 {
+    if a == 0 || b == 0 {
+        return 0;
+    }
+    let log_a = TABLES.log[a as usize] as usize;
+    let log_b = TABLES.log[b as usize] as usize;
+    TABLES.exp[log_a + log_b]
+}
+
+#[inline]
+fn gf_inv(a: u8) -> Option<u8> {
+    if a == 0 {
+        None
+    } else {
+        let idx = FIELD_ORDER - TABLES.log[a as usize] as usize;
+        Some(TABLES.exp[idx])
+    }
+}
+
+#[inline]
+fn gf_scale_row(row: &mut [u8], factor: u8) {
+    if factor == 0 {
+        row.fill(0);
+        return;
+    }
+    for value in row.iter_mut() {
+        *value = gf_mul(*value, factor);
+    }
+}
+
+#[inline]
+fn gf_axpy(target: &mut [u8], factor: u8, source: &[u8]) {
+    if factor == 0 {
+        return;
+    }
+    for (dst, src) in target.iter_mut().zip(source.iter()) {
+        *dst = gf_add(*dst, gf_mul(factor, *src));
+    }
+}
+
+#[derive(Clone)]
+pub struct InhouseReedSolomon {
+    data: usize,
+    parity: usize,
+    generator: Vec<Vec<u8>>,
+}
+
+impl InhouseReedSolomon {
+    pub fn new(data_shards: usize, parity_shards: usize) -> Result<Self, ErasureError> {
+        if data_shards == 0 {
+            return Err(ErasureError::InvalidShardCount {
+                expected: 1,
+                actual: 0,
+            });
+        }
+        let total = data_shards + parity_shards;
+        if total >= FIELD_SIZE {
+            return Err(ErasureError::InvalidShardCount {
+                expected: FIELD_SIZE - 1,
+                actual: total,
+            });
+        }
+        let mut generator = vec![vec![0u8; data_shards]; total];
+        for i in 0..data_shards {
+            generator[i][i] = 1;
+        }
+        for row in 0..parity_shards {
+            let base = TABLES.exp[row];
+            let mut coeff = 1u8;
+            for col in 0..data_shards {
+                generator[data_shards + row][col] = coeff;
+                coeff = gf_mul(coeff, base);
+            }
+        }
+        Ok(Self {
+            data: data_shards,
+            parity: parity_shards,
+            generator,
+        })
+    }
+
+    fn total(&self) -> usize {
+        self.data + self.parity
+    }
+
+    fn generator_row(&self, index: usize) -> &[u8] {
+        &self.generator[index]
+    }
+
+    fn solve_system(
+        &self,
+        mut matrix: Vec<Vec<u8>>,
+        mut values: Vec<Vec<u8>>,
+        shard_len: usize,
+    ) -> Result<Vec<Vec<u8>>, ErasureError> {
+        let mut rank = 0usize;
+        for col in 0..self.data {
+            if rank >= matrix.len() {
+                break;
+            }
+            let mut pivot = None;
+            for row in rank..matrix.len() {
+                if matrix[row][col] != 0 {
+                    pivot = Some(row);
+                    break;
+                }
+            }
+            let Some(pivot_row) = pivot else {
+                continue;
+            };
+            if pivot_row != rank {
+                matrix.swap(rank, pivot_row);
+                values.swap(rank, pivot_row);
+            }
+            let pivot_val = matrix[rank][col];
+            let Some(inv) = gf_inv(pivot_val) else {
+                return Err(ErasureError::ReconstructionFailed(
+                    "singular pivot".to_string(),
+                ));
+            };
+            gf_scale_row(&mut matrix[rank], inv);
+            gf_scale_row(&mut values[rank], inv);
+            let pivot_row_matrix = matrix[rank].clone();
+            let pivot_row_values = values[rank].clone();
+            for row in 0..matrix.len() {
+                if row == rank {
+                    continue;
+                }
+                let factor = matrix[row][col];
+                if factor == 0 {
+                    continue;
+                }
+                gf_axpy(&mut matrix[row], factor, &pivot_row_matrix);
+                matrix[row][col] = 0;
+                gf_axpy(&mut values[row], factor, &pivot_row_values);
+            }
+            rank += 1;
+            if rank == self.data {
+                break;
+            }
+        }
+        if rank < self.data {
+            return Err(ErasureError::ReconstructionFailed(
+                "insufficient independent shards".to_string(),
+            ));
+        }
+        let mut solution = Vec::with_capacity(self.data);
+        for row in 0..self.data {
+            let mut shard = values[row].clone();
+            shard.truncate(shard_len);
+            if shard.len() < shard_len {
+                shard.resize(shard_len, 0);
+            }
+            solution.push(shard);
+        }
+        Ok(solution)
+    }
+}
+
+impl ErasureCoder for InhouseReedSolomon {
+    fn algorithm(&self) -> &'static str {
+        "reed-solomon"
+    }
+
+    fn encode(&self, data: &[u8]) -> Result<ErasureBatch, ErasureError> {
+        let shard_len = if data.is_empty() {
+            0
+        } else {
+            (data.len() + self.data - 1) / self.data
+        };
+        let total = self.total();
+        let mut shards: Vec<Vec<u8>> = Vec::with_capacity(total);
+        for i in 0..self.data {
+            let start = i * shard_len;
+            let end = usize::min(start + shard_len, data.len());
+            let mut shard = vec![0u8; shard_len];
+            if start < end {
+                shard[..end - start].copy_from_slice(&data[start..end]);
+            }
+            shards.push(shard);
+        }
+        for row in 0..self.parity {
+            let mut parity = vec![0u8; shard_len];
+            let coeffs = self.generator_row(self.data + row);
+            for (col, coeff) in coeffs.iter().enumerate() {
+                if *coeff == 0 {
+                    continue;
+                }
+                let data_shard = &shards[col];
+                for (dst, src) in parity.iter_mut().zip(data_shard.iter()) {
+                    *dst = gf_add(*dst, gf_mul(*coeff, *src));
+                }
+            }
+            shards.push(parity);
+        }
+        let metadata = ErasureMetadata {
+            data_shards: self.data,
+            parity_shards: self.parity,
+            shard_len,
+            original_len: data.len(),
+        };
+        let mut out = Vec::with_capacity(total);
+        for (index, shard) in shards.into_iter().enumerate() {
+            let kind = if index < self.data {
+                ErasureShardKind::Data
+            } else {
+                ErasureShardKind::Parity
+            };
+            out.push(ErasureShard {
+                index,
+                kind,
+                bytes: shard,
+            });
+        }
+        Ok(ErasureBatch {
+            metadata,
+            shards: out,
+        })
+    }
+
+    fn reconstruct(
+        &self,
+        metadata: &ErasureMetadata,
+        shards: &[Option<ErasureShard>],
+    ) -> Result<Vec<u8>, ErasureError> {
+        let total = metadata.data_shards + metadata.parity_shards;
+        if shards.len() != total {
+            return Err(ErasureError::InvalidShardCount {
+                expected: total,
+                actual: shards.len(),
+            });
+        }
+        let mut available: Vec<(usize, Vec<u8>)> = Vec::new();
+        for (idx, maybe_shard) in shards.iter().enumerate() {
+            if let Some(shard) = maybe_shard {
+                if shard.index != idx {
+                    return Err(ErasureError::InvalidShardIndex {
+                        index: shard.index,
+                        total,
+                    });
+                }
+                let mut bytes = shard.bytes.clone();
+                if bytes.len() < metadata.shard_len {
+                    bytes.resize(metadata.shard_len, 0);
+                }
+                available.push((idx, bytes));
+            }
+        }
+        if available.len() < metadata.data_shards {
+            return Err(ErasureError::InsufficientShards {
+                expected: metadata.data_shards,
+                available: available.len(),
+            });
+        }
+        let shard_len = metadata.shard_len;
+        let mut matrix = Vec::with_capacity(available.len());
+        let mut values = Vec::with_capacity(available.len());
+        for (index, bytes) in available.into_iter() {
+            matrix.push(self.generator_row(index).to_vec());
+            values.push(bytes);
+        }
+        let solved = self.solve_system(matrix, values, shard_len)?;
+        let mut recovered = Vec::with_capacity(metadata.original_len);
+        for shard in solved.into_iter().take(metadata.data_shards) {
+            recovered.extend_from_slice(&shard);
+        }
+        recovered.truncate(metadata.original_len);
+        Ok(recovered)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generator_is_systematic() {
+        let coder = InhouseReedSolomon::new(4, 2).unwrap();
+        for row in 0..coder.data {
+            let mut expected = vec![0u8; coder.data];
+            expected[row] = 1;
+            assert_eq!(coder.generator_row(row), expected.as_slice());
+        }
+    }
+
+    #[test]
+    fn encode_and_reconstruct_roundtrip() {
+        let coder = InhouseReedSolomon::new(4, 2).unwrap();
+        let data = (0u8..64).collect::<Vec<_>>();
+        let batch = coder.encode(&data).unwrap();
+        let mut shards: Vec<Option<ErasureShard>> = batch.shards.into_iter().map(Some).collect();
+        shards[1] = None;
+        shards[4] = None;
+        let recovered = coder
+            .reconstruct(&batch.metadata, &shards)
+            .expect("should recover");
+        assert_eq!(recovered, data);
+    }
+}

--- a/crates/coding/src/error.rs
+++ b/crates/coding/src/error.rs
@@ -42,6 +42,8 @@ pub enum ErasureError {
     InvalidShardCount { expected: usize, actual: usize },
     #[error("invalid shard index {index} for total {total}")]
     InvalidShardIndex { index: usize, total: usize },
+    #[error("insufficient shards: expected {expected}, available {available}")]
+    InsufficientShards { expected: usize, available: usize },
     #[error("erasure encoding failed: {0}")]
     EncodingFailed(String),
     #[error("erasure reconstruction failed: {0}")]
@@ -50,6 +52,10 @@ pub enum ErasureError {
 
 #[derive(Debug, Error)]
 pub enum FountainError {
+    #[error("invalid fountain symbol size: {size}")]
+    InvalidSymbolSize { size: u16 },
+    #[error("invalid fountain rate: {rate}")]
+    InvalidRate { rate: f32 },
     #[error("fountain encode failed: {0}")]
     Encode(String),
     #[error("fountain decode failed: {0}")]

--- a/crates/coding/src/fountain/inhouse.rs
+++ b/crates/coding/src/fountain/inhouse.rs
@@ -1,0 +1,222 @@
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::{Rng, SeedableRng};
+
+use super::{FountainBatch, FountainCoder, FountainError, FountainMetadata, FountainPacket};
+
+const ALG_LT_INHOUSE: &str = "lt-inhouse";
+
+pub struct InhouseLtFountain {
+    symbol_size: u16,
+    rate: f32,
+}
+
+impl InhouseLtFountain {
+    pub fn new(symbol_size: u16, rate: f32) -> Result<Self, FountainError> {
+        if symbol_size == 0 {
+            return Err(FountainError::InvalidSymbolSize { size: symbol_size });
+        }
+        if !rate.is_finite() || rate < 1.0 {
+            return Err(FountainError::InvalidRate { rate });
+        }
+        Ok(Self { symbol_size, rate })
+    }
+
+    fn symbol_size(&self) -> usize {
+        self.symbol_size as usize
+    }
+
+    fn symbol_count(&self, len: usize) -> usize {
+        if len == 0 {
+            0
+        } else {
+            (len + self.symbol_size() - 1) / self.symbol_size()
+        }
+    }
+
+    fn packet_budget(&self, symbols: usize) -> usize {
+        if symbols == 0 {
+            0
+        } else {
+            let overhead = (symbols as f32 * (self.rate - 1.0)).ceil() as usize;
+            symbols + overhead
+        }
+    }
+
+    fn build_symbols(&self, data: &[u8]) -> Vec<Vec<u8>> {
+        let symbol_len = self.symbol_size();
+        let count = self.symbol_count(data.len());
+        let mut symbols = Vec::with_capacity(count);
+        for idx in 0..count {
+            let start = idx * symbol_len;
+            let end = usize::min(start + symbol_len, data.len());
+            let mut shard = vec![0u8; symbol_len];
+            if start < end {
+                shard[..end - start].copy_from_slice(&data[start..end]);
+            }
+            symbols.push(shard);
+        }
+        symbols
+    }
+
+    fn encode_indices(&self, symbol_count: usize, seq: usize) -> Vec<usize> {
+        if symbol_count == 0 {
+            return Vec::new();
+        }
+        if seq < symbol_count {
+            return vec![seq];
+        }
+        let mut rng = StdRng::seed_from_u64(seq as u64);
+        let degree = rng.gen_range(1..=symbol_count);
+        let mut indices: Vec<usize> = (0..symbol_count).collect();
+        indices.shuffle(&mut rng);
+        indices.truncate(degree);
+        indices.sort_unstable();
+        indices
+    }
+
+    fn combine(symbols: &[Vec<u8>], indices: &[usize]) -> Vec<u8> {
+        if indices.is_empty() {
+            return vec![];
+        }
+        let len = symbols[0].len();
+        let mut out = vec![0u8; len];
+        for &idx in indices {
+            for (dst, src) in out.iter_mut().zip(symbols[idx].iter()) {
+                *dst ^= *src;
+            }
+        }
+        out
+    }
+
+    fn parse_packet<'a>(
+        &'a self,
+        metadata: &FountainMetadata,
+        packet: &'a FountainPacket,
+    ) -> Result<(Vec<usize>, Vec<u8>), FountainError> {
+        let bytes = packet.as_bytes();
+        if bytes.len() < 8 {
+            return Err(FountainError::PacketTruncated { len: bytes.len() });
+        }
+        let mut seed_bytes = [0u8; 8];
+        seed_bytes.copy_from_slice(&bytes[..8]);
+        let seed = u64::from_le_bytes(seed_bytes);
+        let payload = bytes[8..].to_vec();
+        let expected_len = metadata.symbol_size() as usize;
+        if payload.len() != expected_len {
+            return Err(FountainError::PacketTruncated { len: payload.len() });
+        }
+        let indices = self.decode_indices(metadata.symbol_count(), seed as usize);
+        Ok((indices, payload))
+    }
+
+    fn decode_indices(&self, symbol_count: usize, seq: usize) -> Vec<usize> {
+        if symbol_count == 0 {
+            return Vec::new();
+        }
+        if seq < symbol_count {
+            return vec![seq];
+        }
+        let mut rng = StdRng::seed_from_u64(seq as u64);
+        let degree = rng.gen_range(1..=symbol_count);
+        let mut indices: Vec<usize> = (0..symbol_count).collect();
+        indices.shuffle(&mut rng);
+        indices.truncate(degree);
+        indices.sort_unstable();
+        indices
+    }
+}
+
+impl FountainCoder for InhouseLtFountain {
+    fn algorithm(&self) -> &'static str {
+        ALG_LT_INHOUSE
+    }
+
+    fn encode(&self, data: &[u8]) -> Result<FountainBatch, FountainError> {
+        let symbol_count = self.symbol_count(data.len());
+        let symbol_size = self.symbol_size();
+        let symbols = self.build_symbols(data);
+        let total_packets = self.packet_budget(symbol_count);
+        let mut packets = Vec::with_capacity(total_packets);
+        for seq in 0..total_packets {
+            let indices = self.encode_indices(symbol_count, seq);
+            let mut payload = if indices.is_empty() {
+                vec![0u8; symbol_size]
+            } else {
+                Self::combine(&symbols, &indices)
+            };
+            payload.resize(symbol_size, 0);
+            let mut bytes = Vec::with_capacity(8 + payload.len());
+            bytes.extend_from_slice(&(seq as u64).to_le_bytes());
+            bytes.extend_from_slice(&payload);
+            packets.push(FountainPacket::new(bytes));
+        }
+        let metadata = FountainMetadata::new(self.symbol_size, data.len());
+        Ok(FountainBatch { metadata, packets })
+    }
+
+    fn decode(
+        &self,
+        metadata: &FountainMetadata,
+        packets: &[FountainPacket],
+    ) -> Result<Vec<u8>, FountainError> {
+        let symbol_count = metadata.symbol_count();
+        if symbol_count == 0 {
+            return Ok(Vec::new());
+        }
+        let mut equations = Vec::new();
+        for packet in packets {
+            let (indices, payload) = self.parse_packet(metadata, packet)?;
+            if indices.is_empty() {
+                continue;
+            }
+            equations.push((indices, payload));
+        }
+        let mut symbols: Vec<Option<Vec<u8>>> = vec![None; symbol_count];
+        let symbol_len = metadata.symbol_size() as usize;
+        let mut progress = true;
+        while progress {
+            progress = false;
+            for (indices, payload) in equations.iter_mut() {
+                if indices.is_empty() {
+                    if payload.iter().any(|&b| b != 0) {
+                        return Err(FountainError::Decode(
+                            "inconsistent fountain packet set".to_string(),
+                        ));
+                    }
+                    continue;
+                }
+                let mut remaining = Vec::with_capacity(indices.len());
+                for &idx in indices.iter() {
+                    if let Some(symbol) = &symbols[idx] {
+                        for (dst, src) in payload.iter_mut().zip(symbol.iter()) {
+                            *dst ^= *src;
+                        }
+                    } else {
+                        remaining.push(idx);
+                    }
+                }
+                *indices = remaining;
+                if indices.len() == 1 {
+                    let idx = indices[0];
+                    if symbols[idx].is_none() {
+                        let mut value = payload.clone();
+                        value.truncate(symbol_len);
+                        value.resize(symbol_len, 0);
+                        symbols[idx] = Some(value);
+                        progress = true;
+                    }
+                }
+            }
+        }
+        if symbols.iter().any(|entry| entry.is_none()) {
+            return Err(FountainError::InsufficientPackets);
+        }
+        let mut out = Vec::with_capacity(metadata.original_len());
+        for symbol in symbols.into_iter().take(symbol_count) {
+            out.extend_from_slice(symbol.unwrap().as_slice());
+        }
+        out.truncate(metadata.original_len());
+        Ok(out)
+    }
+}

--- a/crates/coding/src/lib.rs
+++ b/crates/coding/src/lib.rs
@@ -6,27 +6,28 @@ mod error;
 mod fountain;
 
 pub use compression::{
-    compressor_for, default_compressor, Compressor, NoopCompressor, RleCompressor, ZstdCompressor,
+    compressor_for, default_compressor, Compressor, InhouseHybrid, NoopCompressor, RleCompressor,
 };
 pub use config::{
     ChunkConfig, CompressionConfig, Config, EncryptionConfig, ErasureConfig, FountainConfig,
     RolloutConfig, DEFAULT_FALLBACK_EMERGENCY_ENV,
 };
 pub use encrypt::{
-    default_encryptor, encryptor_for, ChaCha20Poly1305Encryptor, Encryptor,
+    decrypt_xchacha20_poly1305, default_encryptor, encrypt_xchacha20_poly1305,
+    encrypt_xchacha20_poly1305_with_nonce, encryptor_for, ChaCha20Poly1305Encryptor, Encryptor,
     CHACHA20_POLY1305_KEY_LEN, CHACHA20_POLY1305_NONCE_LEN, CHACHA20_POLY1305_TAG_LEN,
+    XCHACHA20_POLY1305_NONCE_LEN,
 };
 pub use erasure::{
     canonical_algorithm_label, default_erasure_coder, erasure_coder_for, ErasureBatch,
-    ErasureCoder, ErasureMetadata, ErasureShard, ErasureShardKind, ReedSolomonErasureCoder,
-    XorCoder,
+    ErasureCoder, ErasureMetadata, ErasureShard, ErasureShardKind, InhouseReedSolomon, XorCoder,
 };
 pub use error::{
     CodingError, CompressionError, ConfigError, EncryptError, ErasureError, FountainError,
 };
 pub use fountain::{
     default_fountain_coder, fountain_coder_for, FountainBatch, FountainCoder, FountainMetadata,
-    FountainPacket, RaptorqFountainCoder,
+    FountainPacket, InhouseLtFountain,
 };
 
 #[cfg(test)]
@@ -81,7 +82,7 @@ mod tests {
     }
 
     #[test]
-    fn zstd_compression_reduces_size() {
+    fn hybrid_compression_reduces_size() {
         let cfg = Config::default();
         let compressor = cfg.compressor().expect("compressor");
         let data = vec![b'a'; 16 * 1024];

--- a/crates/coding/tests/inhouse_props.rs
+++ b/crates/coding/tests/inhouse_props.rs
@@ -1,0 +1,132 @@
+use coding::{
+    decrypt_xchacha20_poly1305, default_compressor, default_encryptor, encrypt_xchacha20_poly1305,
+    ErasureCoder, FountainCoder, CHACHA20_POLY1305_KEY_LEN, XCHACHA20_POLY1305_NONCE_LEN,
+};
+use rand::seq::SliceRandom;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
+#[test]
+fn encrypt_round_trip_random_inputs() {
+    let mut rng = StdRng::seed_from_u64(1337);
+    for size in [0usize, 1, 7, 64, 255, 1024, 4096] {
+        let mut key = [0u8; CHACHA20_POLY1305_KEY_LEN];
+        rng.fill(&mut key);
+        let encryptor = default_encryptor(&key).expect("encryptor");
+        let mut payload = vec![0u8; size];
+        rng.fill(payload.as_mut_slice());
+        let ciphertext = encryptor.encrypt(&payload).expect("encrypt");
+        let plaintext = encryptor.decrypt(&ciphertext).expect("decrypt");
+        assert_eq!(plaintext, payload);
+    }
+}
+
+#[test]
+fn encrypt_detects_single_bit_flips() {
+    let mut rng = StdRng::seed_from_u64(9001);
+    let mut key = [0u8; CHACHA20_POLY1305_KEY_LEN];
+    rng.fill(&mut key);
+    let encryptor = default_encryptor(&key).expect("encryptor");
+    let mut payload = vec![0u8; 512];
+    rng.fill(payload.as_mut_slice());
+    let ciphertext = encryptor.encrypt(&payload).expect("encrypt");
+    for idx in CHACHA20_POLY1305_KEY_LEN..ciphertext.len() {
+        let mut tampered = ciphertext.clone();
+        tampered[idx] ^= 0x80;
+        assert!(encryptor.decrypt(&tampered).is_err());
+    }
+}
+
+#[test]
+fn xchacha_round_trip_random_inputs() {
+    let mut rng = StdRng::seed_from_u64(424242);
+    for size in [0usize, 7, 128, 4096] {
+        let mut key = [0u8; CHACHA20_POLY1305_KEY_LEN];
+        rng.fill(&mut key);
+        let mut payload = vec![0u8; size];
+        rng.fill(payload.as_mut_slice());
+        let ciphertext = encrypt_xchacha20_poly1305(&key, &payload).expect("encrypt");
+        let plaintext = decrypt_xchacha20_poly1305(&key, &ciphertext).expect("decrypt");
+        assert_eq!(plaintext, payload);
+    }
+}
+
+#[test]
+fn xchacha_detects_tampering() {
+    let mut rng = StdRng::seed_from_u64(0xfeed5eed);
+    let mut key = [0u8; CHACHA20_POLY1305_KEY_LEN];
+    rng.fill(&mut key);
+    let mut payload = vec![0u8; 256];
+    rng.fill(payload.as_mut_slice());
+    let ciphertext = encrypt_xchacha20_poly1305(&key, &payload).expect("encrypt");
+    for idx in XCHACHA20_POLY1305_NONCE_LEN..ciphertext.len() {
+        let mut tampered = ciphertext.clone();
+        tampered[idx] ^= 0x01;
+        assert!(
+            decrypt_xchacha20_poly1305(&key, &tampered).is_err(),
+            "tampering index {idx} passed"
+        );
+    }
+}
+
+#[test]
+fn hybrid_compressor_handles_entropy_spectrum() {
+    let compressor = default_compressor();
+    let mut rng = StdRng::seed_from_u64(4242);
+    for len in [0usize, 32, 128, 1024, 8192] {
+        let mut data = vec![0u8; len];
+        rng.fill(data.as_mut_slice());
+        let encoded = compressor.compress(&data).expect("compress");
+        let decoded = compressor.decompress(&encoded).expect("decompress");
+        assert_eq!(decoded, data);
+    }
+}
+
+#[test]
+fn hybrid_preserves_low_entropy_data() {
+    let compressor = default_compressor();
+    let mut data = Vec::new();
+    data.extend(std::iter::repeat(0u8).take(8192));
+    data.extend((0u8..=255).cycle().take(2048));
+    let encoded = compressor.compress(&data).expect("compress");
+    let decoded = compressor.decompress(&encoded).expect("decompress");
+    assert_eq!(decoded, data);
+}
+
+#[test]
+fn reed_solomon_recovers_varied_losses() {
+    use coding::InhouseReedSolomon;
+    let coder = InhouseReedSolomon::new(8, 4).expect("coder");
+    let mut rng = StdRng::seed_from_u64(0x5eed5eed);
+    let data: Vec<u8> = (0..16_384).map(|idx| (idx % 251) as u8).collect();
+    let batch = coder.encode(&data).expect("encode");
+    let total = batch.shards.len();
+    for missing in [1usize, 2, 4] {
+        let mut slots: Vec<Option<coding::ErasureShard>> =
+            batch.shards.clone().into_iter().map(Some).collect();
+        let mut indices: Vec<usize> = (0..total).collect();
+        indices.shuffle(&mut rng);
+        for idx in indices.iter().take(missing) {
+            slots[*idx] = None;
+        }
+        let recovered = coder
+            .reconstruct(&batch.metadata, &slots)
+            .expect("reconstruct");
+        assert_eq!(recovered, data, "loss {missing}");
+    }
+}
+
+#[test]
+fn fountain_recovers_after_packet_loss() {
+    use coding::InhouseLtFountain;
+    let coder = InhouseLtFountain::new(512, 1.5).expect("fountain");
+    let mut rng = StdRng::seed_from_u64(0x1234_5678);
+    let mut data = vec![0u8; 32 * 1024];
+    rng.fill(data.as_mut_slice());
+    let batch = coder.encode(&data).expect("encode");
+    let (metadata, mut packets) = batch.into_parts();
+    packets.shuffle(&mut rng);
+    let losses = packets.len() / 5;
+    packets.truncate(packets.len() - losses);
+    let recovered = coder.decode(&metadata, &packets).expect("decode");
+    assert_eq!(recovered, data);
+}

--- a/crates/jurisdiction/src/lib.rs
+++ b/crates/jurisdiction/src/lib.rs
@@ -1,9 +1,6 @@
 #[cfg(feature = "pq")]
 use base64::Engine as _;
-use crypto_suite::signatures::{
-    ed25519::{Signature, VerifyingKey},
-    Verifier,
-};
+use crypto_suite::signatures::ed25519::{Signature, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;

--- a/crates/light-client/Cargo.toml
+++ b/crates/light-client/Cargo.toml
@@ -26,8 +26,8 @@ blake3 = "1"
 flate2 = "1"
 tokio = { version = "1", features = ["rt", "macros", "net", "time", "sync"] }
 futures = "0.3"
-zstd = "0.12"
 bincode = "1"
+coding = { path = "../coding" }
 crypto_suite = { path = "../crypto_suite" }
 tracing = "0.1"
 state = { path = "../../state" }

--- a/crates/storage_engine/Cargo.toml
+++ b/crates/storage_engine/Cargo.toml
@@ -14,6 +14,8 @@ parking_lot = "0.12"
 tempfile = "3"
 base64 = "0.22"
 bincode = "1.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 rocksdb = { version = "0.21", optional = true }
 sled = { version = "0.34", optional = true }
 

--- a/crates/storage_engine/src/inhouse_engine.rs
+++ b/crates/storage_engine/src/inhouse_engine.rs
@@ -1,0 +1,731 @@
+#![forbid(unsafe_code)]
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, RwLock};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    KeyValue, KeyValueBatch, KeyValueIterator, StorageError, StorageMetrics, StorageResult,
+};
+
+const MANIFEST_FILE: &str = "manifest.json";
+const WAL_FILE: &str = "wal.log";
+const DEFAULT_MEMTABLE_LIMIT: usize = 8 * 1024 * 1024;
+const DEFAULT_CACHE_CAPACITY: usize = 32;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Manifest {
+    cfs: HashMap<String, CfManifest>,
+}
+
+impl Manifest {
+    fn load(path: &Path) -> StorageResult<Self> {
+        let manifest_path = path.join(MANIFEST_FILE);
+        if !manifest_path.exists() {
+            return Ok(Manifest {
+                cfs: HashMap::new(),
+            });
+        }
+        let data = fs::read(&manifest_path).map_err(StorageError::from)?;
+        serde_json::from_slice(&data).map_err(StorageError::backend)
+    }
+
+    fn store(&self, path: &Path) -> StorageResult<()> {
+        let manifest_path = path.join(MANIFEST_FILE);
+        let tmp_path = manifest_path.with_extension("tmp");
+        let data = serde_json::to_vec_pretty(self).map_err(StorageError::backend)?;
+        fs::write(&tmp_path, data).map_err(StorageError::from)?;
+        fs::rename(&tmp_path, &manifest_path).map_err(StorageError::from)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CfManifest {
+    next_file_id: u64,
+    sstables: Vec<SstMeta>,
+    sequence: u64,
+}
+
+impl CfManifest {
+    fn new() -> Self {
+        Self {
+            next_file_id: 0,
+            sstables: Vec::new(),
+            sequence: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SstMeta {
+    file: String,
+    max_sequence: u64,
+    #[serde(default)]
+    min_key: Vec<u8>,
+    #[serde(default)]
+    max_key: Vec<u8>,
+}
+
+#[derive(Clone)]
+pub struct InhouseEngine {
+    root: Arc<PathBuf>,
+    inner: Arc<EngineInner>,
+}
+
+struct EngineInner {
+    manifest: RwLock<Manifest>,
+    cfs: RwLock<HashMap<String, Arc<CfHandle>>>,
+    memtable_limit: RwLock<Option<usize>>,
+    cache: Mutex<SstCache>,
+}
+
+struct CfHandle {
+    name: String,
+    path: PathBuf,
+    state: Mutex<CfState>,
+}
+
+struct CfState {
+    memtable: BTreeMap<Vec<u8>, TableEntry>,
+    memtable_bytes: usize,
+    manifest: CfManifest,
+}
+
+impl EngineInner {
+    fn load_table(&self, path: &Path) -> StorageResult<Arc<Vec<TableEntry>>> {
+        {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some(entries) = cache.get(path) {
+                return Ok(entries);
+            }
+        }
+        let entries = read_table(path)?;
+        let arc = Arc::new(entries);
+        let mut cache = self.cache.lock().unwrap();
+        cache.insert(path.to_path_buf(), arc.clone());
+        Ok(arc)
+    }
+
+    fn invalidate_table(&self, path: &Path) {
+        self.cache.lock().unwrap().remove(path);
+    }
+}
+
+#[derive(Default)]
+struct SstCache {
+    entries: HashMap<PathBuf, Arc<Vec<TableEntry>>>,
+    order: VecDeque<PathBuf>,
+    limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TableEntry {
+    key: Vec<u8>,
+    sequence: u64,
+    value: ValueState,
+}
+
+impl SstCache {
+    fn new(limit: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            limit,
+        }
+    }
+
+    fn get(&mut self, path: &Path) -> Option<Arc<Vec<TableEntry>>> {
+        let path = path.to_path_buf();
+        if let Some(entry) = self.entries.get(&path).cloned() {
+            self.order.retain(|p| p != &path);
+            self.order.push_back(path);
+            Some(entry)
+        } else {
+            None
+        }
+    }
+
+    fn insert(&mut self, path: PathBuf, entries: Arc<Vec<TableEntry>>) {
+        if self.limit == 0 {
+            return;
+        }
+        if self.entries.contains_key(&path) {
+            self.order.retain(|p| p != &path);
+        }
+        self.entries.insert(path.clone(), entries);
+        self.order.push_back(path.clone());
+        while self.order.len() > self.limit {
+            if let Some(evicted) = self.order.pop_front() {
+                self.entries.remove(&evicted);
+            }
+        }
+    }
+
+    fn remove(&mut self, path: &Path) {
+        let path = path.to_path_buf();
+        self.entries.remove(&path);
+        self.order.retain(|p| p != &path);
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+enum ValueState {
+    Present(Vec<u8>),
+    Tombstone,
+}
+
+impl TableEntry {
+    fn value_bytes(&self) -> Option<&[u8]> {
+        match &self.value {
+            ValueState::Present(ref value) => Some(value.as_slice()),
+            ValueState::Tombstone => None,
+        }
+    }
+}
+
+pub struct InhouseIterator {
+    data: Vec<(Vec<u8>, Vec<u8>)>,
+    index: usize,
+}
+
+impl KeyValueIterator for InhouseIterator {
+    fn next(&mut self) -> StorageResult<Option<(Vec<u8>, Vec<u8>)>> {
+        if self.index >= self.data.len() {
+            Ok(None)
+        } else {
+            let item = self.data[self.index].clone();
+            self.index += 1;
+            Ok(Some(item))
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct InhouseBatch {
+    ops: Vec<BatchOp>,
+}
+
+enum BatchOp {
+    Put {
+        cf: String,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    },
+    Delete {
+        cf: String,
+        key: Vec<u8>,
+    },
+}
+
+impl KeyValueBatch for InhouseBatch {
+    fn put(&mut self, cf: &str, key: &[u8], value: &[u8]) -> StorageResult<()> {
+        self.ops.push(BatchOp::Put {
+            cf: cf.to_string(),
+            key: key.to_vec(),
+            value: value.to_vec(),
+        });
+        Ok(())
+    }
+
+    fn delete(&mut self, cf: &str, key: &[u8]) -> StorageResult<()> {
+        self.ops.push(BatchOp::Delete {
+            cf: cf.to_string(),
+            key: key.to_vec(),
+        });
+        Ok(())
+    }
+}
+
+impl InhouseEngine {
+    pub fn open(path: &str) -> StorageResult<Self> {
+        let root = PathBuf::from(path);
+        fs::create_dir_all(&root).map_err(StorageError::from)?;
+        let manifest = Manifest::load(&root)?;
+        let inner = EngineInner {
+            manifest: RwLock::new(manifest),
+            cfs: RwLock::new(HashMap::new()),
+            memtable_limit: RwLock::new(Some(DEFAULT_MEMTABLE_LIMIT)),
+            cache: Mutex::new(SstCache::new(DEFAULT_CACHE_CAPACITY)),
+        };
+        let engine = InhouseEngine {
+            root: Arc::new(root),
+            inner: Arc::new(inner),
+        };
+        engine.reload_cfs()?;
+        Ok(engine)
+    }
+
+    fn reload_cfs(&self) -> StorageResult<()> {
+        let manifest = self.inner.manifest.read().unwrap().clone();
+        for (cf, _) in &manifest.cfs {
+            let _ = self.cf_handle(cf)?;
+        }
+        Ok(())
+    }
+
+    fn cf_handle(&self, cf: &str) -> StorageResult<Arc<CfHandle>> {
+        if let Some(existing) = self.inner.cfs.read().unwrap().get(cf) {
+            return Ok(existing.clone());
+        }
+        let mut write_guard = self.inner.cfs.write().unwrap();
+        if let Some(existing) = write_guard.get(cf) {
+            return Ok(existing.clone());
+        }
+        let cf_path = self.root.join(cf);
+        fs::create_dir_all(&cf_path).map_err(StorageError::from)?;
+        let manifest = {
+            let mut manifest_guard = self.inner.manifest.write().unwrap();
+            manifest_guard
+                .cfs
+                .entry(cf.to_string())
+                .or_insert_with(CfManifest::new)
+                .clone()
+        };
+        let mut state = CfState {
+            memtable: BTreeMap::new(),
+            memtable_bytes: 0,
+            manifest,
+        };
+        state.replay_wal(&cf_path)?;
+        if state.ensure_key_ranges(&cf_path, &self.inner)? {
+            self.persist_manifest(cf, &state.manifest)?;
+        }
+        let handle = Arc::new(CfHandle {
+            name: cf.to_string(),
+            path: cf_path,
+            state: Mutex::new(state),
+        });
+        write_guard.insert(cf.to_string(), handle.clone());
+        Ok(handle)
+    }
+
+    fn with_cf<R, F>(&self, cf: &str, f: F) -> StorageResult<R>
+    where
+        F: FnOnce(&mut CfState, &Path, &EngineInner) -> StorageResult<R>,
+    {
+        let handle = self.cf_handle(cf)?;
+        let mut guard = handle.state.lock().unwrap();
+        let result = f(&mut guard, &handle.path, &self.inner);
+        if result.is_ok() {
+            self.persist_manifest(&handle.name, &guard.manifest)?;
+        }
+        result
+    }
+
+    fn persist_manifest(&self, cf: &str, manifest: &CfManifest) -> StorageResult<()> {
+        let mut manifest_guard = self.inner.manifest.write().unwrap();
+        manifest_guard.cfs.insert(cf.to_string(), manifest.clone());
+        manifest_guard.store(&self.root)
+    }
+}
+
+impl CfState {
+    fn replay_wal(&mut self, cf_path: &Path) -> StorageResult<()> {
+        let wal_path = cf_path.join(WAL_FILE);
+        if !wal_path.exists() {
+            return Ok(());
+        }
+        let mut wal_reader = File::open(&wal_path).map_err(StorageError::from)?;
+        wal_reader
+            .seek(SeekFrom::Start(0))
+            .map_err(StorageError::from)?;
+        let mut buf = String::new();
+        wal_reader
+            .read_to_string(&mut buf)
+            .map_err(StorageError::from)?;
+        for line in buf.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let record: WalRecord = serde_json::from_str(line).map_err(StorageError::backend)?;
+            self.apply_record(record);
+        }
+        Ok(())
+    }
+
+    fn apply_record(&mut self, record: WalRecord) {
+        self.manifest.sequence = self.manifest.sequence.max(record.sequence);
+        match record.kind {
+            WalKind::Put { value } => {
+                let entry = TableEntry {
+                    key: record.key.clone(),
+                    sequence: record.sequence,
+                    value: ValueState::Present(value),
+                };
+                self.insert_mem(entry);
+            }
+            WalKind::Delete => {
+                let entry = TableEntry {
+                    key: record.key.clone(),
+                    sequence: record.sequence,
+                    value: ValueState::Tombstone,
+                };
+                self.insert_mem(entry);
+            }
+        }
+    }
+
+    fn insert_mem(&mut self, entry: TableEntry) {
+        self.memtable_bytes = self
+            .memtable_bytes
+            .saturating_sub(self.memtable.get(&entry.key).map(byte_cost).unwrap_or(0));
+        self.memtable_bytes += byte_cost(&entry);
+        self.memtable.insert(entry.key.clone(), entry);
+    }
+
+    fn allocate_sequence(&mut self) -> u64 {
+        self.manifest.sequence += 1;
+        self.manifest.sequence
+    }
+
+    fn append_wal(&mut self, cf_path: &Path, record: &WalRecord) -> StorageResult<()> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(cf_path.join(WAL_FILE))
+            .map_err(StorageError::from)?;
+        let encoded = serde_json::to_vec(record).map_err(StorageError::backend)?;
+        file.write_all(&encoded).map_err(StorageError::from)?;
+        file.write_all(b"\n").map_err(StorageError::from)?;
+        file.sync_all().map_err(StorageError::from)
+    }
+
+    fn maybe_flush(
+        &mut self,
+        cf_path: &Path,
+        engine: &EngineInner,
+        limit: Option<usize>,
+    ) -> StorageResult<()> {
+        if let Some(limit) = limit {
+            if self.memtable_bytes >= limit {
+                self.flush_memtable(cf_path, engine)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn flush_memtable(&mut self, cf_path: &Path, engine: &EngineInner) -> StorageResult<()> {
+        if self.memtable.is_empty() {
+            return Ok(());
+        }
+        let mut entries: Vec<TableEntry> = self.memtable.values().cloned().collect();
+        entries.sort_by(|a, b| a.key.cmp(&b.key).then(a.sequence.cmp(&b.sequence)));
+        let filename = format!("sst-{:020}.bin", self.manifest.next_file_id);
+        self.manifest.next_file_id += 1;
+        let max_sequence = entries.iter().map(|e| e.sequence).max().unwrap_or(0);
+        let table_path = cf_path.join(&filename);
+        let data = bincode::serialize(&entries).map_err(StorageError::backend)?;
+        fs::write(&table_path, data).map_err(StorageError::from)?;
+        let min_key = entries.first().map(|e| e.key.clone()).unwrap_or_default();
+        let max_key = entries.last().map(|e| e.key.clone()).unwrap_or_default();
+        self.manifest.sstables.push(SstMeta {
+            file: filename,
+            max_sequence,
+            min_key,
+            max_key,
+        });
+        self.memtable.clear();
+        self.memtable_bytes = 0;
+        // reset wal
+        fs::write(cf_path.join(WAL_FILE), &[]).map_err(StorageError::from)?;
+        engine.invalidate_table(&table_path);
+        Ok(())
+    }
+
+    fn compact(&mut self, cf_path: &Path, engine: &EngineInner) -> StorageResult<()> {
+        if self.manifest.sstables.len() < 2 {
+            return Ok(());
+        }
+        let mut merged = BTreeMap::<Vec<u8>, TableEntry>::new();
+        for meta in &self.manifest.sstables {
+            let table_path = cf_path.join(&meta.file);
+            let entries = engine.load_table(&table_path)?;
+            for entry in entries.iter() {
+                match merged.get(&entry.key) {
+                    Some(existing) if existing.sequence > entry.sequence => {}
+                    _ => {
+                        merged.insert(entry.key.clone(), entry.clone());
+                    }
+                }
+            }
+        }
+        let mut entries: Vec<TableEntry> = merged.into_values().collect();
+        entries.sort_by(|a, b| a.key.cmp(&b.key).then(a.sequence.cmp(&b.sequence)));
+        let filename = format!("sst-{:020}.bin", self.manifest.next_file_id);
+        self.manifest.next_file_id += 1;
+        let max_sequence = entries.iter().map(|e| e.sequence).max().unwrap_or(0);
+        let data = bincode::serialize(&entries).map_err(StorageError::backend)?;
+        let table_path = cf_path.join(&filename);
+        fs::write(&table_path, data).map_err(StorageError::from)?;
+        let min_key = entries.first().map(|e| e.key.clone()).unwrap_or_default();
+        let max_key = entries.last().map(|e| e.key.clone()).unwrap_or_default();
+        for meta in &self.manifest.sstables {
+            let old_path = cf_path.join(&meta.file);
+            let _ = fs::remove_file(&old_path);
+            engine.invalidate_table(&old_path);
+        }
+        self.manifest.sstables = vec![SstMeta {
+            file: filename,
+            max_sequence,
+            min_key,
+            max_key,
+        }];
+        Ok(())
+    }
+
+    fn ensure_key_ranges(&mut self, cf_path: &Path, engine: &EngineInner) -> StorageResult<bool> {
+        let mut updated = false;
+        for meta in &mut self.manifest.sstables {
+            if meta.min_key.is_empty() || meta.max_key.is_empty() {
+                let table_path = cf_path.join(&meta.file);
+                let entries = engine.load_table(&table_path)?;
+                if let Some(first) = entries.first() {
+                    meta.min_key = first.key.clone();
+                }
+                if let Some(last) = entries.last() {
+                    meta.max_key = last.key.clone();
+                }
+                updated = true;
+            }
+        }
+        Ok(updated)
+    }
+
+    fn scan(
+        &self,
+        cf_path: &Path,
+        engine: &EngineInner,
+        prefix: &[u8],
+    ) -> StorageResult<Vec<(Vec<u8>, Vec<u8>)>> {
+        let mut merged: BTreeMap<Vec<u8>, TableEntry> = BTreeMap::new();
+        for entry in self.memtable.values() {
+            merged.insert(entry.key.clone(), entry.clone());
+        }
+        for meta in self.manifest.sstables.iter().rev() {
+            let table_path = cf_path.join(&meta.file);
+            let entries = engine.load_table(&table_path)?;
+            for entry in entries.iter() {
+                merged
+                    .entry(entry.key.clone())
+                    .and_modify(|existing| {
+                        if existing.sequence < entry.sequence {
+                            *existing = entry.clone();
+                        }
+                    })
+                    .or_insert(entry.clone());
+            }
+        }
+        let mut data = Vec::new();
+        for (key, entry) in merged {
+            if !key.starts_with(prefix) {
+                continue;
+            }
+            if let Some(value) = entry.value_bytes() {
+                data.push((key, value.to_vec()));
+            }
+        }
+        Ok(data)
+    }
+
+    fn get(
+        &self,
+        cf_path: &Path,
+        engine: &EngineInner,
+        key: &[u8],
+    ) -> StorageResult<Option<Vec<u8>>> {
+        if let Some(entry) = self.memtable.get(key) {
+            return Ok(entry.value_bytes().map(|v| v.to_vec()));
+        }
+        for meta in self.manifest.sstables.iter().rev() {
+            let table_path = cf_path.join(&meta.file);
+            let entries = engine.load_table(&table_path)?;
+            for entry in entries.iter().rev() {
+                if entry.key == key {
+                    return Ok(entry.value_bytes().map(|v| v.to_vec()));
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
+fn read_table(path: &Path) -> StorageResult<Vec<TableEntry>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let data = fs::read(path).map_err(StorageError::from)?;
+    bincode::deserialize(&data).map_err(StorageError::backend)
+}
+
+fn byte_cost(entry: &TableEntry) -> usize {
+    let value_len = entry.value_bytes().map(|v| v.len()).unwrap_or(0);
+    entry.key.len() + value_len + std::mem::size_of::<u64>() + 1
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct WalRecord {
+    key: Vec<u8>,
+    sequence: u64,
+    kind: WalKind,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum WalKind {
+    Put { value: Vec<u8> },
+    Delete,
+}
+
+impl KeyValue for InhouseEngine {
+    type Batch = InhouseBatch;
+    type Iter = InhouseIterator;
+
+    fn open(path: &str) -> StorageResult<Self> {
+        InhouseEngine::open(path)
+    }
+
+    fn flush_wal(&self) -> StorageResult<()> {
+        let handles = self.inner.cfs.read().unwrap().clone();
+        for handle in handles.values() {
+            let wal_path = handle.path.join(WAL_FILE);
+            if wal_path.exists() {
+                let file = OpenOptions::new()
+                    .append(true)
+                    .open(&wal_path)
+                    .map_err(StorageError::from)?;
+                file.sync_all().map_err(StorageError::from)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn ensure_cf(&self, cf: &str) -> StorageResult<()> {
+        let _ = self.cf_handle(cf)?;
+        Ok(())
+    }
+
+    fn get(&self, cf: &str, key: &[u8]) -> StorageResult<Option<Vec<u8>>> {
+        self.with_cf(cf, |state, path, engine| state.get(path, engine, key))
+    }
+
+    fn put(&self, cf: &str, key: &[u8], value: &[u8]) -> StorageResult<Option<Vec<u8>>> {
+        let previous = self.get(cf, key)?;
+        self.put_bytes(cf, key, value)?;
+        Ok(previous)
+    }
+
+    fn put_bytes(&self, cf: &str, key: &[u8], value: &[u8]) -> StorageResult<()> {
+        let limit = *self.inner.memtable_limit.read().unwrap();
+        self.with_cf(cf, |state, path, engine| {
+            let sequence = state.allocate_sequence();
+            let record = WalRecord {
+                key: key.to_vec(),
+                sequence,
+                kind: WalKind::Put {
+                    value: value.to_vec(),
+                },
+            };
+            state.append_wal(path, &record)?;
+            state.apply_record(record);
+            state.maybe_flush(path, engine, limit)
+        })
+    }
+
+    fn delete(&self, cf: &str, key: &[u8]) -> StorageResult<Option<Vec<u8>>> {
+        let previous = self.get(cf, key)?;
+        let limit = *self.inner.memtable_limit.read().unwrap();
+        self.with_cf(cf, |state, path, engine| {
+            let sequence = state.allocate_sequence();
+            let record = WalRecord {
+                key: key.to_vec(),
+                sequence,
+                kind: WalKind::Delete,
+            };
+            state.append_wal(path, &record)?;
+            state.apply_record(record);
+            state.maybe_flush(path, engine, limit)
+        })?;
+        Ok(previous)
+    }
+
+    fn prefix_iterator(&self, cf: &str, prefix: &[u8]) -> StorageResult<Self::Iter> {
+        let data = self.with_cf(cf, |state, path, engine| state.scan(path, engine, prefix))?;
+        Ok(InhouseIterator { data, index: 0 })
+    }
+
+    fn list_cfs(&self) -> StorageResult<Vec<String>> {
+        let manifest = self.inner.manifest.read().unwrap();
+        Ok(manifest.cfs.keys().cloned().collect())
+    }
+
+    fn make_batch(&self) -> Self::Batch {
+        InhouseBatch::default()
+    }
+
+    fn write_batch(&self, batch: Self::Batch) -> StorageResult<()> {
+        for op in batch.ops {
+            match op {
+                BatchOp::Put { cf, key, value } => {
+                    self.put_bytes(&cf, &key, &value)?;
+                }
+                BatchOp::Delete { cf, key } => {
+                    let _ = self.delete(&cf, &key)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn flush(&self) -> StorageResult<()> {
+        let limit = *self.inner.memtable_limit.read().unwrap();
+        let handles = self.inner.cfs.read().unwrap().clone();
+        for handle in handles.values() {
+            let mut state = handle.state.lock().unwrap();
+            state.maybe_flush(&handle.path, &self.inner, limit)?;
+        }
+        Ok(())
+    }
+
+    fn compact(&self) -> StorageResult<()> {
+        let handles = self.inner.cfs.read().unwrap().clone();
+        for handle in handles.values() {
+            let mut state = handle.state.lock().unwrap();
+            state.flush_memtable(&handle.path, &self.inner)?;
+            state.compact(&handle.path, &self.inner)?;
+        }
+        Ok(())
+    }
+
+    fn set_byte_limit(&self, limit: Option<usize>) -> StorageResult<()> {
+        *self.inner.memtable_limit.write().unwrap() = limit;
+        Ok(())
+    }
+
+    fn metrics(&self) -> StorageResult<StorageMetrics> {
+        let handles = self.inner.cfs.read().unwrap().clone();
+        let mut mem_bytes = 0usize;
+        let mut sst_bytes = 0u64;
+        for handle in handles.values() {
+            let state = handle.state.lock().unwrap();
+            mem_bytes += state.memtable_bytes;
+            for meta in &state.manifest.sstables {
+                let path = handle.path.join(&meta.file);
+                if let Ok(metadata) = fs::metadata(path) {
+                    sst_bytes += metadata.len();
+                }
+            }
+        }
+        Ok(StorageMetrics {
+            backend: "inhouse",
+            memtable_bytes: Some(mem_bytes as u64),
+            total_sst_bytes: Some(sst_bytes),
+            pending_compactions: None,
+            running_compactions: None,
+            level0_files: None,
+            size_on_disk_bytes: Some((mem_bytes as u64) + sst_bytes),
+        })
+    }
+}

--- a/crates/storage_engine/src/lib.rs
+++ b/crates/storage_engine/src/lib.rs
@@ -3,6 +3,7 @@
 mod error;
 pub use error::{StorageError, StorageResult};
 
+pub mod inhouse_engine;
 pub mod memory_engine;
 #[cfg(feature = "rocksdb")]
 pub mod rocksdb_engine;

--- a/crates/storage_engine/tests/inhouse_engine.rs
+++ b/crates/storage_engine/tests/inhouse_engine.rs
@@ -1,0 +1,126 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use storage_engine::{inhouse_engine::InhouseEngine, KeyValue, KeyValueIterator};
+
+fn temp_dir(name: &str) -> PathBuf {
+    let mut base = std::env::temp_dir();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    base.push(format!(
+        "the-block-inhouse-{name}-{}-{}",
+        std::process::id(),
+        nanos
+    ));
+    fs::create_dir_all(&base).expect("create temp dir");
+    base
+}
+
+fn cleanup(path: &Path) {
+    let _ = fs::remove_dir_all(path);
+}
+
+#[test]
+fn wal_replayed_on_reopen() {
+    let path = temp_dir("wal-replay");
+    {
+        let engine = InhouseEngine::open(path.to_string_lossy().as_ref()).expect("open");
+        engine.ensure_cf("default").expect("cf");
+        engine.put_bytes("default", b"alpha", b"one").expect("put");
+        engine.put_bytes("default", b"beta", b"two").expect("put");
+    }
+
+    let engine = InhouseEngine::open(path.to_string_lossy().as_ref()).expect("reopen");
+    let alpha = engine.get("default", b"alpha").expect("get");
+    assert_eq!(alpha, Some(b"one".to_vec()));
+    let beta = engine.get("default", b"beta").expect("get");
+    assert_eq!(beta, Some(b"two".to_vec()));
+    cleanup(&path);
+}
+
+#[test]
+fn delete_tombstone_persists_through_flush() {
+    let path = temp_dir("delete");
+    let engine = InhouseEngine::open(path.to_string_lossy().as_ref()).expect("open");
+    engine.ensure_cf("default").expect("cf");
+    engine.put_bytes("default", b"key", b"value").expect("put");
+    engine.flush().expect("flush");
+    let value = engine.get("default", b"key").expect("get");
+    assert_eq!(value, Some(b"value".to_vec()));
+    let deleted = engine.delete("default", b"key").expect("delete");
+    assert_eq!(deleted, Some(b"value".to_vec()));
+    engine.flush().expect("flush");
+    assert_eq!(engine.get("default", b"key").unwrap(), None);
+    drop(engine);
+    let engine = InhouseEngine::open(path.to_string_lossy().as_ref()).expect("reopen");
+    assert_eq!(engine.get("default", b"key").unwrap(), None);
+    cleanup(&path);
+}
+
+#[test]
+fn compaction_retains_latest_values() {
+    let path = temp_dir("compact");
+    let engine = InhouseEngine::open(path.to_string_lossy().as_ref()).expect("open");
+    engine.ensure_cf("default").expect("cf");
+    engine.set_byte_limit(Some(128)).expect("limit");
+    for idx in 0..32 {
+        let key = format!("key-{idx:03}");
+        engine
+            .put_bytes("default", key.as_bytes(), key.as_bytes())
+            .expect("put initial");
+    }
+    engine.flush().expect("flush");
+    for idx in 0..32 {
+        let key = format!("key-{idx:03}");
+        let newer = format!("v2-{idx:03}");
+        engine
+            .put_bytes("default", key.as_bytes(), newer.as_bytes())
+            .expect("put newer");
+    }
+    engine.compact().expect("compact");
+    for idx in 0..32 {
+        let key = format!("key-{idx:03}");
+        let expected = format!("v2-{idx:03}");
+        assert_eq!(
+            engine.get("default", key.as_bytes()).expect("get"),
+            Some(expected.into_bytes())
+        );
+    }
+    cleanup(&path);
+}
+
+#[test]
+fn prefix_iterator_respects_prefix() {
+    let path = temp_dir("iterator");
+    let engine = InhouseEngine::open(path.to_string_lossy().as_ref()).expect("open");
+    engine.ensure_cf("metrics").expect("cf");
+    engine
+        .put_bytes("metrics", b"peer:001", b"one")
+        .expect("put 1");
+    engine
+        .put_bytes("metrics", b"peer:002", b"two")
+        .expect("put 2");
+    engine
+        .put_bytes("metrics", b"other:003", b"three")
+        .expect("put 3");
+    let mut iter = engine
+        .prefix_iterator("metrics", b"peer:")
+        .expect("iterator");
+    let mut keys = Vec::new();
+    while let Some((key, value)) = iter.next().expect("iter next") {
+        keys.push((
+            String::from_utf8(key).unwrap(),
+            String::from_utf8(value).unwrap(),
+        ));
+    }
+    keys.sort();
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0].0, "peer:001");
+    assert_eq!(keys[0].1, "one");
+    assert_eq!(keys[1].0, "peer:002");
+    assert_eq!(keys[1].1, "two");
+    cleanup(&path);
+}

--- a/docs/architecture/node.md
+++ b/docs/architecture/node.md
@@ -722,7 +722,6 @@ the_block v0.1.0 (/workspace/the-block/node)
 │   └── pyo3-build-config v0.24.2 (*)
 ├── rand v0.8.5 (*)
 ├── rand_core v0.6.4 (*)
-├── raptorq v2.0.0
 ├── rayon v1.11.0
 │   ├── either v1.15.0
 │   └── rayon-core v1.13.0
@@ -731,25 +730,6 @@ the_block v0.1.0 (/workspace/the-block/node)
 │       │   │   └── crossbeam-utils v0.8.21
 │       │   └── crossbeam-utils v0.8.21
 │       └── crossbeam-utils v0.8.21
-├── reed-solomon-erasure v6.0.0
-│   ├── libm v0.2.15
-│   ├── lru v0.7.8
-│   │   └── hashbrown v0.12.3
-│   │       └── ahash v0.7.8
-│   │           ├── getrandom v0.2.16 (*)
-│   │           └── once_cell v1.21.3
-│   │           [build-dependencies]
-│   │           └── version_check v0.9.5
-│   ├── parking_lot v0.11.2
-│   │   ├── instant v0.1.13 (*)
-│   │   ├── lock_api v0.4.13 (*)
-│   │   └── parking_lot_core v0.8.6
-│   │       ├── cfg-if v1.0.3
-│   │       ├── instant v0.1.13 (*)
-│   │       ├── libc v0.2.175
-│   │       └── smallvec v1.15.1
-│   ├── smallvec v1.15.1
-│   └── spin v0.9.8
 ├── regex v1.11.2
 │   ├── aho-corasick v1.1.3
 │   │   └── memchr v2.7.5

--- a/docs/dependency_inventory.md
+++ b/docs/dependency_inventory.md
@@ -545,6 +545,7 @@
 | unclassified | `redox_syscall` | 0.5.17 | crates.io | MIT | 3 |
 | unclassified | `redox_users` | 0.4.6 | crates.io | MIT | 3 |
 | unclassified | `reed-solomon-erasure` | 6.0.0 | crates.io | MIT | 1 |
+> **Update (2025-09-30):** `raptorq` and `reed-solomon-erasure` were replaced by in-house coders; the next automated export will drop them from this inventory.
 | unclassified | `regalloc2` | 0.9.3 | crates.io | Apache-2.0 WITH LLVM-exception | 4 |
 | unclassified | `regex` | 1.11.2 | crates.io | MIT OR Apache-2.0 | 1 |
 | unclassified | `regex-automata` | 0.4.10 | crates.io | MIT OR Apache-2.0 | 2 |

--- a/docs/governance_release.md
+++ b/docs/governance_release.md
@@ -1,5 +1,5 @@
 # Governance-Secured Release Flow
-> **Review (2025-09-25):** Synced Governance-Secured Release Flow guidance with the dependency-sovereignty pivot and confirmed readiness + token hygiene.
+> **Review (2025-09-30):** Documented overlay peer-store migration helper in release prep checklist.
 > Dependency pivot status: Runtime, transport, overlay, storage_engine, coding, crypto_suite, and codec wrappers are live with governance overrides enforced (2025-09-25).
 
 This document outlines the process for approving and installing node
@@ -21,6 +21,27 @@ attested by a quorum of release signers.
    confirms that the shipped snapshot aligns with the committed policy baseline. Governance
    proposals should include the vendor digest and snapshot path so operators can cross-check
    artifacts before voting.
+
+Prior to rolling out a release that upgrades the in-house overlay backend, run the bundled
+peer-store migrator so persisted peer IDs land in the new canonical path. Nodes that still
+store peers in `~/.the_block/overlay_peers.json` should execute:
+
+```
+cargo run --bin migrate_overlay_store --release -- \
+  ~/.the_block/overlay_peers.json ~/.the_block/overlay/peers.json
+```
+
+For bespoke layouts, supply explicit source and destination paths:
+
+```
+cargo run --bin migrate_overlay_store --release -- \
+  /srv/the-block/overlay_peers.json /var/lib/the-block/overlay/peers.json
+```
+
+The helper canonicalises every peer ID to base58-check form and stamps the migration timestamp
+so uptime probes immediately recognise the refreshed entries. See
+[`docs/operators/run_a_node.md`](operators/run_a_node.md#migrating-overlay-peer-stores) for
+additional validation commands.
 
 Wallets expose two helper commands:
 

--- a/docs/light_client_stream.md
+++ b/docs/light_client_stream.md
@@ -1,5 +1,5 @@
 # Light Client State Streaming Protocol
-> **Review (2025-09-25):** Synced Light Client State Streaming Protocol guidance with the dependency-sovereignty pivot and confirmed readiness + token hygiene.
+> **Review (2025-09-30):** Documented hybrid snapshot compression and updated telemetry strings.
 > Dependency pivot status: Runtime, transport, overlay, storage_engine, coding, crypto_suite, and codec wrappers are live with governance overrides enforced (2025-09-25).
 
 Light clients maintain an up-to-date account view by subscribing to the
@@ -14,8 +14,8 @@ state stream exposed over WebSockets. Each `StateChunk` carries:
   - `proof` – Merkle proof (`state::trie::Proof`) attesting to the tuple
     `(balance, account_seq)` under the supplied root.
 - `root` – Merkle root for the account entries in the chunk.
-- `compressed` – flag indicating whether the payload was zstd-compressed by the
-  sender (currently `false` for live diffs).
+- `compressed` – flag indicating whether the payload was compressed with the
+  in-house `lz77-rle` codec by the sender (currently `false` for live diffs).
 
 ## Chunk Processing
 

--- a/docs/pivot_dependency_strategy.md
+++ b/docs/pivot_dependency_strategy.md
@@ -1,5 +1,5 @@
 # Pivot Dependency Strategy Runbook
-> **Review (2025-09-25):** Synced Pivot Dependency Strategy Runbook guidance with the dependency-sovereignty pivot and confirmed readiness + token hygiene.
+> **Review (2025-09-30):** Captured the in-house Reed–Solomon/LT fountain rollout and refreshed coding wrapper notes.
 > Dependency pivot status: Runtime, transport, overlay, storage_engine, coding, crypto_suite, and codec wrappers are live with governance overrides enforced (2025-09-25).
 
 This runbook aligns engineering and operations on the hybrid dependency strategy that
@@ -27,6 +27,7 @@ summaries, letting governance stage cutovers with confidence.
 vendor hashes, and policy attestations. The `tools/vendor_sync` helper keeps the vendored
 tree reproducible, while `tools/dependency_registry` records policy-compliant snapshots
 for auditing.
+Recent updates removed third-party Reed–Solomon and RaptorQ dependencies in favour of the in-house `coding` crate implementations; wrapper telemetry and policy rollout now track the `lt-inhouse` fountain and GF(256) Reed–Solomon identifiers so governance can audit the swap.
 
 ## 2. Wrapper Flow Diagram
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,5 @@
 # Project Progress Snapshot
-> **Review (2025-09-29):** Tightened readiness to 98.3/93.3 after re-checking that the aggregator and gateway servers still rely on `axum`/`hyper` and that `crates/httpd` currently serves outbound clients only.
+> **Review (2025-09-30):** Logged hybrid crypto rollout and queued next dependency snapshot.
 > Dependency pivot status: Runtime, transport, overlay, storage_engine, coding, crypto_suite, and codec wrappers are live with governance overrides enforced (2025-09-29).
 
 This document tracks high‑fidelity progress across The‑Block's major work streams.  Each subsection lists the current completion estimate, supporting evidence with canonical file or module references, and the remaining gaps.  Percentages are rough, *engineer-reported* gauges meant to guide prioritization rather than marketing claims.
@@ -21,8 +21,9 @@ with hysteresis `ΔN ≈ √N*` to blunt flash joins. Full derivations live in [
 ## Dependency posture
 
 - **Policy source**: [`config/dependency_policies.toml`](../config/dependency_policies.toml) enforces a depth limit of 3, assigns risk tiers, and blocks AGPL/SSPL transitively.  The registry snapshot is materialised via `cargo run -p dependency_registry -- --check config/dependency_policies.toml` and stored at [`docs/dependency_inventory.json`](dependency_inventory.json).
-- **Current inventory** *(generated at `2025-09-29T08:45:00Z`)*: 7 strategic crates, 7 replaceable crates, and 845 unclassified dependencies in the resolved workspace DAG.
-- **Outstanding drift**: 204 dependencies currently breach policy depth and are tracked in [`docs/dependency_inventory.violations.json`](dependency_inventory.violations.json).  CI now uploads the generated registry and policy violations for each pull request and posts a summary so reviewers can block regressions quickly.
+- **Current inventory** *(generated at `2025-09-30T12:54:59.759213+00:00`)*: 7 strategic crates, 7 replaceable crates, and 841 unclassified dependencies in the resolved workspace DAG.
+- **Outstanding drift**: 210 dependencies currently breach policy depth and are tracked in [`docs/dependency_inventory.violations.json`](dependency_inventory.violations.json).  CI now uploads the generated registry and policy violations for each pull request and posts a summary so reviewers can block regressions quickly.
+- **Next refresh**: Run `./scripts/dependency_snapshot.sh` on **2025-10-01** after the explorer `codec` link lands to capture the updated workspace DAG and refresh these metrics.
 
 ## 1. Consensus & Core Execution — 93.6 %
 
@@ -46,7 +47,7 @@ with hysteresis `ΔN ≈ √N*` to blunt flash joins. Full derivations live in [
 - Formal safety/liveness proofs under `formal/` still stubbed.
 - No large‑scale network rollback simulation.
 
-## 2. Networking & Gossip — 98.3 %
+## 2. Networking & Gossip — 98.4 %
 
 **Evidence**
 - Runtime-owned TCP/UDP reactor now backs the node RPC client/server plumbing (`crates/runtime/src/net.rs`, `node/src/rpc/client.rs`), while gateway and metrics-aggregator endpoints still rely on `hyper`/`axum` pending their migration. Buffered IO helpers live in `crates/runtime/src/io.rs` with integration coverage in `crates/runtime/tests/net.rs`.
@@ -112,7 +113,7 @@ with hysteresis `ΔN ≈ √N*` to blunt flash joins. Full derivations live in [
 - Read acknowledgement batching and audit flow documented in `docs/read_receipts.md` and `docs/storage_pipeline.md`.
 - Disk‑full metrics and recovery tests (`node/tests/storage_disk_full.rs`).
 - Gateway HTTP parsing fuzz harness (`gateway/fuzz`).
-- RaptorQ progressive fountain overlay for BLE repair (`node/src/storage/repair.rs`, `docs/storage/repair.md`, `node/tests/raptorq_repair.rs`).
+- In-house LT fountain overlay for BLE repair (`node/src/storage/repair.rs`, `docs/storage/repair.md`, `node/tests/fountain_repair.rs`).
 - Thread-safe `ReadStats` telemetry and analytics RPC (`node/src/telemetry.rs`, `node/tests/analytics.rs`).
 - WAL-backed `SimpleDb` design in `docs/simple_db.md` underpins DNS cache, chunk gossip, and DEX storage.
 - Unified `storage_engine` crate wraps RocksDB, sled, and in-memory engines with shared traits, concurrency-safe batches, crash-tested temp dirs, and configuration-driven overrides (`crates/storage_engine`, `node/src/simple_db/mod.rs`).
@@ -188,7 +189,7 @@ with hysteresis `ΔN ≈ √N*` to blunt flash joins. Full derivations live in [
 - Mobile light client with push notification hooks (`examples/mobile`, `docs/mobile_light_client.md`).
 - Light-client synchronization and header verification documented in `docs/light_client.md`.
 - Device status probes integrate Android/iOS power and connectivity hints, cache asynchronous readings with graceful degradation, emit `the_block_light_client_device_status{field,freshness}` telemetry, persist overrides in `~/.the_block/light_client.toml`, surface CLI/RPC gating messages, and embed annotated snapshots in compressed log uploads (`crates/light-client`, `cli/src/light_client.rs`, `docs/light_client.md`, `docs/mobile_light_client.md`).
-- Real-time state streaming over WebSockets with zstd snapshots (`docs/light_client_stream.md`, `node/src/rpc/state_stream.rs`).
+- Real-time state streaming over WebSockets with hybrid (lz77-rle) snapshots (`docs/light_client_stream.md`, `node/src/rpc/state_stream.rs`).
 - Optional KYC provider wiring (`docs/kyc.md`).
 - Session-key issuance and meta-transaction tooling (`crypto/src/session.rs`, `cli/src/wallet.rs`, `docs/account_abstraction.md`).
 - Telemetry `session_key_issued_total`/`session_key_expired_total` and simulator churn knob (`sim/src/lib.rs`).

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -1,13 +1,13 @@
 # Snapshot and Restore
-> **Review (2025-09-25):** Synced Snapshot and Restore guidance with the dependency-sovereignty pivot and confirmed readiness + token hygiene.
+> **Review (2025-09-30):** Updated snapshot tooling docs for the hybrid `lz77-rle` compressor.
 > Dependency pivot status: Runtime, transport, overlay, storage_engine, coding, crypto_suite, and codec wrappers are live with governance overrides enforced (2025-09-25).
 
 The snapshot tool creates deterministic RocksDB archives for quick bootstrap.
 
 ## Creating a Snapshot
-Use `snapshot create <db> <out.zst>` to produce a zstd-compressed archive with an embedded checksum. Metric `snapshot_created_total` counts successful operations.
+Use `snapshot create <db> <out.lz77>` to produce an archive compressed with the in-house `lz77-rle` codec. Metric `snapshot_created_total` counts successful operations.
 
 ## Restoring
-`snapshot restore <archive.zst> <db>` reconstructs the database. Failures increment `snapshot_restore_fail_total`.
+`snapshot restore <archive.lz77> <db>` reconstructs the database. Failures increment `snapshot_restore_fail_total`.
 
 Governance controls the snapshot schedule via the `snapshot_interval` parameter.

--- a/docs/storage/repair.md
+++ b/docs/storage/repair.md
@@ -1,9 +1,9 @@
 # Storage Repair Overlay
-> **Review (2025-09-25):** Synced Storage Repair Overlay guidance with the dependency-sovereignty pivot and confirmed readiness + token hygiene.
+> **Review (2025-09-30):** Updated repair overlay notes for the in-house LT fountain coder and helper rename.
 > Dependency pivot status: Runtime, transport, overlay, storage_engine, coding, crypto_suite, and codec wrappers are live with governance overrides enforced (2025-09-25).
 
 To sustain blob recovery over low-bandwidth BLE links, the repair path uses a
-RaptorQ fountain overlay tuned with the following constants:
+in-house LT fountain overlay tuned with the following constants:
 
 ```
 chunk size   : 4 MiB
@@ -15,6 +15,6 @@ At this rate a 4 GB object requires no more than 25 MB of extra symbols while
 achieving a 99 % success probability for reconstructing any single missing
 shard.
 
-The `raptorq_repair_roundtrip` helper in `storage::repair` exercises this
+The `fountain_repair_roundtrip` helper in `storage::repair` exercises this
 configuration and is used in tests to verify recovery after a simulated
 single‑shard loss.

--- a/docs/storage_market.md
+++ b/docs/storage_market.md
@@ -1,5 +1,5 @@
 # Storage Market Design
-> **Review (2025-09-25):** Synced Storage Market Design guidance with the dependency-sovereignty pivot and confirmed readiness + token hygiene.
+> **Review (2025-09-30):** Captured in-house crypto/erasure/fountain defaults and refreshed rollout guidance.
 > Dependency pivot status: Runtime, transport, overlay, storage_engine, coding, crypto_suite, and codec wrappers are live with governance overrides enforced (2025-09-25).
 
 This document outlines the incentive-compatible storage market where nodes
@@ -63,9 +63,11 @@ use the new settings.
   reduced parity guarantees. The repair worker automatically downgrades expectations when
   multiple data shards are missing and logs the `algorithm_limited` skip reason instead of
   repeatedly failing reconstruction.
+- Adjust `fountain.symbol_size` or `fountain.rate` to tune the in-house LT coder. The
+  default `algorithm = "lt-inhouse"` seeds packets deterministically so `storage::repair::fountain_repair_roundtrip` and the node tests can peel losses without extra metadata.
 - Set `compression.algorithm = "rle"` to switch to the lightweight run-length compressor
-  for environments where zstd cannot be deployed. The compressor reports `algorithm="rle"`
-  in telemetry so dashboards can compare compression ratios across rollout cohorts.
+  when the default hybrid `lz77-rle` backend must be avoided. Telemetry reports
+  `algorithm="rle"` so dashboards can compare compression ratios across rollout cohorts.
 - Because the configuration lives alongside other storage settings, operators can stage
   partial rollouts by first updating a canary node's `storage.toml`, validating telemetry,
   then promoting the change to the wider fleet once confidence is established.

--- a/explorer/Cargo.toml
+++ b/explorer/Cargo.toml
@@ -8,6 +8,7 @@ rusqlite = { version = "0.30", features=["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 hex = "0.4"
 bincode = "1.3"
+codec = { path = "../crates/codec" }
 axum = { version = "0.7", features = ["macros"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow = "1"

--- a/explorer/src/gov_param_view.rs
+++ b/explorer/src/gov_param_view.rs
@@ -1,5 +1,5 @@
+use crate::decode_json;
 use anyhow::{Context, Result};
-use codec::{self, profiles};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -37,8 +37,8 @@ pub fn fee_floor_policy_history(path: impl AsRef<Path>) -> Result<Vec<FeeFloorPo
     }
     let bytes =
         std::fs::read(&history_file).with_context(|| format!("read {}", history_file.display()))?;
-    let mut records: Vec<FeeFloorPolicyRecord> = codec::deserialize(profiles::json(), &bytes)
-        .with_context(|| "decode fee floor policy history")?;
+    let mut records: Vec<FeeFloorPolicyRecord> =
+        decode_json(&bytes).with_context(|| "decode fee floor policy history")?;
     records.sort_by_key(|rec| rec.epoch);
     Ok(records)
 }
@@ -51,8 +51,8 @@ pub fn dependency_policy_history(path: impl AsRef<Path>) -> Result<Vec<Dependenc
     }
     let bytes =
         std::fs::read(&history_file).with_context(|| format!("read {}", history_file.display()))?;
-    let mut records: Vec<DependencyPolicyRecord> = codec::deserialize(profiles::json(), &bytes)
-        .with_context(|| "decode dependency policy history")?;
+    let mut records: Vec<DependencyPolicyRecord> =
+        decode_json(&bytes).with_context(|| "decode dependency policy history")?;
     records.sort_by_key(|rec| rec.epoch);
     Ok(records)
 }

--- a/metrics-aggregator/Cargo.toml
+++ b/metrics-aggregator/Cargo.toml
@@ -20,17 +20,16 @@ blake3 = "1"
 bytes = "1"
 etcd-client = { version = "0.11", optional = true }
 notify = "6"
-sled = "0.34"
 age = "0.9"
 openssl = { version = "0.10", features = ["vendored"] }
 aws-sdk-s3 = { version = "1", optional = true, default-features = false, features = ["rustls"] }
 aws-config = { version = "1", optional = true, default-features = false, features = ["rustls"] }
 urlencoding = "2"
 tracing = "0.1"
+storage_engine = { path = "../crates/storage_engine" }
 
 [dev-dependencies]
 tower = "0.5"
-tempfile = "3"
 regex = "1"
 
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -42,7 +42,6 @@ pqcrypto-dilithium = { version = "0.5", optional = true }
 privacy = { path = "../privacy", optional = true }
 crc32fast = "1"
 tempfile = "3"
-chacha20poly1305 = "0.10"
 thiserror = "1"
 proptest = { version = "1", optional = true }
 dashmap = "5"

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -307,6 +307,7 @@ fn allowed_contains(list: &[String], candidate: &str) -> bool {
 fn parse_engine_kind(name: &str) -> Option<EngineKind> {
     match name {
         "memory" => Some(EngineKind::Memory),
+        "inhouse" => Some(EngineKind::Inhouse),
         "rocksdb" => Some(EngineKind::RocksDb),
         "sled" => Some(EngineKind::Sled),
         _ => None,

--- a/node/src/exec.rs
+++ b/node/src/exec.rs
@@ -10,10 +10,7 @@ use crate::compute_market::settlement;
 #[cfg(feature = "telemetry")]
 use crate::telemetry::{SUBSIDY_BYTES_TOTAL, SUBSIDY_CPU_MS_TOTAL};
 use blake3::{self, Hasher};
-use crypto_suite::signatures::{
-    ed25519::{Signature, VerifyingKey},
-    Verifier,
-};
+use crypto_suite::signatures::ed25519::{Signature, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use serde_bytes;
 

--- a/node/src/gateway/dns.rs
+++ b/node/src/gateway/dns.rs
@@ -1,9 +1,8 @@
 use super::{mobile_cache, read_receipt};
 use crate::simple_db::{names, SimpleDb};
 use crate::ERR_DNS_SIG_INVALID;
-use crypto_suite::signatures::{
-    ed25519::{Signature, VerifyingKey, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH},
-    Verifier,
+use crypto_suite::signatures::ed25519::{
+    Signature, VerifyingKey, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH,
 };
 use hex;
 use once_cell::sync::Lazy;

--- a/node/src/gossip/relay.rs
+++ b/node/src/gossip/relay.rs
@@ -28,6 +28,7 @@ use crate::telemetry::{
 };
 
 use crate::range_boost;
+use p2p_overlay::PeerId;
 
 #[derive(Clone)]
 struct GossipSettings {
@@ -87,7 +88,10 @@ impl ShardStore {
     #[cfg(test)]
     fn temporary() -> Self {
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.into_path().join("gossip_store");
+        let base = dir
+            .keep()
+            .unwrap_or_else(|(_, err)| panic!("preserve gossip tempdir: {err}"));
+        let path = base.join("gossip_store");
         let path_str = path.to_string_lossy().to_string();
         Self::with_factory(&path_str, &SimpleDb::open_named)
     }

--- a/node/src/identity/did.rs
+++ b/node/src/identity/did.rs
@@ -2,10 +2,7 @@ use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use blake3::hash;
-use crypto_suite::signatures::{
-    ed25519::{Signature, VerifyingKey},
-    Verifier,
-};
+use crypto_suite::signatures::ed25519::{Signature, VerifyingKey};
 use hex;
 use ledger::address;
 use serde::{Deserialize, Serialize};

--- a/node/src/identity/handle_registry.rs
+++ b/node/src/identity/handle_registry.rs
@@ -1,9 +1,6 @@
 use crate::{simple_db::names, SimpleDb};
 use blake3::Hasher;
-use crypto_suite::signatures::{
-    ed25519::{Signature, VerifyingKey},
-    Verifier,
-};
+use crypto_suite::signatures::ed25519::{Signature, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
 use unicode_normalization::UnicodeNormalization;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -20,10 +20,7 @@ use crate::consensus::observer;
 use crate::telemetry::MemoryComponent;
 use crate::transaction::{TxSignature, TxVersion};
 use blake3;
-use crypto_suite::signatures::{
-    ed25519::{Signature, SigningKey, VerifyingKey},
-    Signer, Verifier,
-};
+use crypto_suite::signatures::ed25519::{Signature, SigningKey, VerifyingKey};
 use dashmap::DashMap;
 use hex;
 use ledger::address::{self, ShardId};

--- a/node/src/light_client/proof_tracker.rs
+++ b/node/src/light_client/proof_tracker.rs
@@ -376,8 +376,9 @@ mod tests {
 
     fn tracker_with_tempdir() -> ProofTracker {
         let dir = tempdir().expect("tempdir");
-        #[allow(deprecated)]
-        let base = dir.into_path();
+        let base = dir
+            .keep()
+            .unwrap_or_else(|(_, err)| panic!("preserve proof tracker tempdir: {err}"));
         let path = base.join("rebates");
         ProofTracker::open(path)
     }

--- a/node/src/localnet/mod.rs
+++ b/node/src/localnet/mod.rs
@@ -1,8 +1,7 @@
 use bincode;
 use blake3;
-use crypto_suite::signatures::{
-    ed25519::{Signature, VerifyingKey, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH},
-    Verifier,
+use crypto_suite::signatures::ed25519::{
+    Signature, VerifyingKey, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH,
 };
 use hex;
 use serde::{Deserialize, Serialize};

--- a/node/src/net/message.rs
+++ b/node/src/net/message.rs
@@ -1,6 +1,6 @@
 use crate::net::peer::ReputationUpdate;
 use crate::{p2p::handshake::Hello, BlobTx, Block, SignedTransaction};
-use crypto_suite::signatures::{ed25519::SigningKey, Signer};
+use crypto_suite::signatures::ed25519::SigningKey;
 use ledger::address::ShardId;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;

--- a/node/src/net/partition_watch.rs
+++ b/node/src/net/partition_watch.rs
@@ -7,7 +7,6 @@ use std::sync::{
 use once_cell::sync::Lazy;
 
 use super::OverlayPeerId;
-
 #[cfg(feature = "telemetry")]
 use crate::telemetry::PARTITION_EVENTS_TOTAL;
 
@@ -162,6 +161,30 @@ mod tests {
         assert_eq!(isolated[0].as_bytes(), overlay.as_bytes());
 
         watch.mark_reachable(overlay);
+        assert!(!watch.is_partitioned());
+        assert!(watch.isolated_peers().is_empty());
+    }
+
+    #[cfg(not(feature = "telemetry"))]
+    #[test]
+    fn threshold_reset_without_telemetry_never_sets_marker() {
+        let watch = PartitionWatch::new(3);
+        let a = peer(11);
+        let b = peer(22);
+
+        watch.mark_unreachable(a.clone());
+        assert!(!watch.is_partitioned());
+        assert_eq!(watch.current_marker(), None);
+
+        watch.mark_unreachable(b.clone());
+        assert!(!watch.is_partitioned());
+        assert_eq!(watch.current_marker(), None);
+
+        watch.mark_reachable(b);
+        assert!(!watch.is_partitioned());
+        assert_eq!(watch.current_marker(), None);
+
+        watch.mark_reachable(a);
         assert!(!watch.is_partitioned());
         assert!(watch.isolated_peers().is_empty());
     }

--- a/node/src/net/peer.rs
+++ b/node/src/net/peer.rs
@@ -10,10 +10,7 @@ use crate::p2p::handshake::validate_quic_certificate;
 use crate::p2p::handshake::Transport;
 use crate::simple_db::{names, SimpleDb};
 use crate::Blockchain;
-use crypto_suite::signatures::{
-    ed25519::{Signature, VerifyingKey},
-    Verifier,
-};
+use crypto_suite::signatures::ed25519::{Signature, VerifyingKey};
 use fs2::FileExt;
 use hex;
 use indexmap::IndexMap;

--- a/node/src/net/uptime.rs
+++ b/node/src/net/uptime.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
 
-use p2p_overlay::{OverlayResult, UptimeMetrics};
+use p2p_overlay::OverlayResult;
+#[cfg(feature = "telemetry")]
+use p2p_overlay::UptimeMetrics;
 
 #[cfg(feature = "telemetry")]
 use crate::telemetry::{REBATE_CLAIMS_TOTAL, REBATE_ISSUED_TOTAL};

--- a/node/src/provenance.rs
+++ b/node/src/provenance.rs
@@ -1,7 +1,6 @@
 use blake3::hash;
-use crypto_suite::signatures::{
-    ed25519::{Signature, VerifyingKey, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH},
-    Verifier,
+use crypto_suite::signatures::ed25519::{
+    Signature, VerifyingKey, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH,
 };
 use hex;
 use once_cell::sync::Lazy;

--- a/node/src/read_receipt.rs
+++ b/node/src/read_receipt.rs
@@ -1,8 +1,5 @@
 use blake3::Hasher;
-use crypto_suite::signatures::{
-    ed25519::{Signature, VerifyingKey},
-    Verifier,
-};
+use crypto_suite::signatures::ed25519::{Signature, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use serde_bytes;
 

--- a/node/src/rpc/mod.rs
+++ b/node/src/rpc/mod.rs
@@ -17,10 +17,7 @@ use ::storage::{contract::StorageContract, offer::StorageOffer};
 use base64::engine::general_purpose;
 use base64::Engine;
 use bincode;
-use crypto_suite::signatures::{
-    ed25519::{Signature, VerifyingKey},
-    Verifier,
-};
+use crypto_suite::signatures::ed25519::{Signature, VerifyingKey};
 use hex;
 use once_cell::sync::Lazy;
 use runtime::io::BufferedTcpStream;

--- a/node/src/rpc/peer.rs
+++ b/node/src/rpc/peer.rs
@@ -1,5 +1,4 @@
 use crate::net::uptime;
-use hex;
 use jsonrpc_core::{BoxFuture, Params, Result};
 
 pub fn rebate_status(params: Params) -> Result<BoxFuture<Result<String>>> {

--- a/node/src/rpc/pos.rs
+++ b/node/src/rpc/pos.rs
@@ -1,10 +1,7 @@
 use std::collections::HashSet;
 use std::sync::Mutex;
 
-use crypto_suite::signatures::{
-    ed25519::{Signature, VerifyingKey, SIGNATURE_LENGTH},
-    Verifier,
-};
+use crypto_suite::signatures::ed25519::{Signature, VerifyingKey, SIGNATURE_LENGTH};
 use once_cell::sync::Lazy;
 use serde_json::Value;
 

--- a/node/src/storage/erasure.rs
+++ b/node/src/storage/erasure.rs
@@ -78,6 +78,9 @@ pub fn encode_with_params(chunk: &[u8], params: &ErasureParams) -> Result<Vec<Ve
             return Err(err.to_string());
         }
     };
+    if cfg!(not(feature = "telemetry")) {
+        let _ = &algo;
+    }
     let shards: Vec<Vec<u8>> = batch.shards.into_iter().map(|shard| shard.bytes).collect();
     Ok(overlay_fountain(shards))
 }
@@ -106,6 +109,9 @@ pub fn reconstruct_with_params(
         base.push(iter.next().unwrap_or(None));
     }
     let overlays: Vec<Option<Vec<u8>>> = iter.collect();
+    if cfg!(not(feature = "telemetry")) {
+        let _ = &algo;
+    }
     if base.get(0).map(|s| s.is_none()).unwrap_or(false)
         || base.get(1).map(|s| s.is_none()).unwrap_or(false)
     {

--- a/node/src/storage/pipeline.rs
+++ b/node/src/storage/pipeline.rs
@@ -153,6 +153,9 @@ fn manifest_erasure_params(manifest: &ObjectManifest) -> Result<ErasureParams, S
 
 fn decrypt_chunk(encryptor: &dyn Encryptor, blob: &[u8]) -> Result<Vec<u8>, String> {
     let algorithm = encryptor.algorithm();
+    if cfg!(not(feature = "telemetry")) {
+        let _ = &algorithm;
+    }
     match encryptor.decrypt(blob) {
         Ok(bytes) => {
             #[cfg(feature = "telemetry")]
@@ -172,6 +175,9 @@ fn decrypt_chunk(encryptor: &dyn Encryptor, blob: &[u8]) -> Result<Vec<u8>, Stri
 
 fn decompress_chunk(compressor: &dyn Compressor, data: Vec<u8>) -> Result<Vec<u8>, String> {
     let algorithm = compressor.algorithm();
+    if cfg!(not(feature = "telemetry")) {
+        let _ = &algorithm;
+    }
     match compressor.decompress(&data) {
         Ok(bytes) => {
             #[cfg(feature = "telemetry")]
@@ -754,6 +760,9 @@ impl StoragePipeline {
                 #[cfg(feature = "telemetry")]
                 let chunk_start = Instant::now();
                 let compression_algo = compressor.algorithm();
+                if cfg!(not(feature = "telemetry")) {
+                    let _ = &compression_algo;
+                }
                 let compressed = match compressor.compress(chunk) {
                     Ok(data) => {
                         #[cfg(feature = "telemetry")]
@@ -779,6 +788,9 @@ impl StoragePipeline {
                     }
                 };
                 let encrypt_algo = algorithms.encryptor();
+                if cfg!(not(feature = "telemetry")) {
+                    let _ = &encrypt_algo;
+                }
                 let blob = match encryptor.encrypt(&compressed) {
                     Ok(ciphertext) => {
                         #[cfg(feature = "telemetry")]

--- a/node/src/storage/repair.rs
+++ b/node/src/storage/repair.rs
@@ -40,6 +40,8 @@ pub fn spawn(path: String, period: Duration) {
         let log = RepairLog::new(Path::new(&path).join("repair_log"));
         loop {
             if let Err(err) = run_once(&mut db, &log, RepairRequest::default()) {
+                #[cfg(not(feature = "telemetry"))]
+                let _ = &err;
                 #[cfg(feature = "telemetry")]
                 {
                     let algorithms = settings::algorithms();
@@ -891,9 +893,9 @@ fn current_timestamp() -> i64 {
     OffsetDateTime::now_utc().unix_timestamp()
 }
 
-/// Encodes `data` into RaptorQ packets with the BLE-tuned parameters and decodes
+/// Encodes `data` into fountain packets with the BLE-tuned parameters and decodes
 /// them after dropping a single packet, returning the recovered bytes.
-pub fn raptorq_repair_roundtrip(data: &[u8]) -> Result<Vec<u8>, String> {
+pub fn fountain_repair_roundtrip(data: &[u8]) -> Result<Vec<u8>, String> {
     let coder = settings::fountain();
     let batch = coder.encode(data).map_err(|e| e.to_string())?;
     let (metadata, mut packets) = batch.into_parts();

--- a/node/src/telemetry.rs
+++ b/node/src/telemetry.rs
@@ -58,7 +58,7 @@ const KNOWN_RUNTIME_BACKENDS: [&str; 2] = ["tokio", "stub"];
 #[cfg(feature = "telemetry")]
 const KNOWN_TRANSPORT_PROVIDERS: [&str; 2] = ["quinn", "s2n-quic"];
 #[cfg(feature = "telemetry")]
-const KNOWN_STORAGE_ENGINES: [&str; 3] = ["memory", "rocksdb", "sled"];
+const KNOWN_STORAGE_ENGINES: [&str; 4] = ["memory", "inhouse", "rocksdb", "sled"];
 #[cfg(feature = "telemetry")]
 const KNOWN_CODEC_PROFILES: &[(&str, &[&str])] = &[
     ("bincode", &["transaction", "gossip", "storage_manifest"]),

--- a/node/tests/fountain_repair.rs
+++ b/node/tests/fountain_repair.rs
@@ -1,11 +1,11 @@
 #![cfg(feature = "integration-tests")]
-use the_block::storage::repair::raptorq_repair_roundtrip;
+use the_block::storage::repair::fountain_repair_roundtrip;
 
 #[test]
-fn raptorq_recovers_single_loss() {
+fn fountain_recovers_single_loss() {
     // Use a 256 KiB shard which exercises the repair path while keeping the test
     // comfortably under the harness timeout.
     let data = vec![42u8; 256 * 1024];
-    let recovered = raptorq_repair_roundtrip(&data).expect("repair");
+    let recovered = fountain_repair_roundtrip(&data).expect("repair");
     assert_eq!(recovered, data);
 }

--- a/tools/log_indexer_cli/Cargo.toml
+++ b/tools/log_indexer_cli/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2021"
 [dependencies]
 base64 = "0.22"
 blake3 = "1"
-chacha20poly1305 = "0.10"
 clap = { version = "4", features = ["derive"] }
-rand = "0.8"
 rusqlite = { version = "0.30", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+coding = { path = "../crates/coding" }


### PR DESCRIPTION
Finite-field erasure coding now ships with its own generator matrix builder and Gauss–Jordan solver, letting the crate encode and reconstruct shards without external tables. The LT-style fountain encoder adds deterministic symbol selection and overhead budgeting so packet loss tolerance can be tuned per workload. Our ChaCha20-Poly1305 module implements the quarter rounds, HChaCha20 derivation, and Poly1305 clamping directly to avoid third-party AEAD dependencies. HybridCompressor pairs an LZ77 search window with literal flushing and a streaming decoder, replacing the zstd binding while preserving API symmetry. Streaming variants handle incremental pushes and finishing to keep large-object compression deterministic across chunking boundaries. Property suites now cover random round-trips, tamper detection, entropy-heavy payloads, and fountain packet loss to assert the new primitives match expectations. These tests rely on seeded RNGs and shuffle logic, giving repeatable fingerprints for CI and debugging runs. Future work should extend the property harness with differential comparisons against the retired libraries to capture edge-case divergences before runtime exposure.

The in-house storage engine introduces manifests, WAL replay, memtable tracking, and SST metadata to bring RocksDB-class capabilities into the workspace itself. Replay logic walks per-CF JSONL logs and rehydrates memtables so crashes no longer require external recovery tooling. Dedicated tests assert WAL replay, tombstone flush, compaction retention, and prefix iteration semantics across reopen cycles. SimpleDb now defaults to the in-house backend and keeps feature-flag fallbacks, which means all named handles inherit the new durability without code churn at call sites. The metrics aggregator consumes the same engine, enforcing column families and WAL-backed retention for telemetry snapshots and correlation records. Settlement initialization preserves temporary directories via keep() so migration staging can audit the new batch writes without losing context. Storage pipeline decrypt and decompress helpers now record algorithm telemetry only when the feature is enabled, preventing unused variable warnings in lean builds. Operators can migrate legacy stores using the new CLI, which scans column families, computes checksums, and emits the in-house layout for cutovers.

Networking state now exposes a scoped gossip relay guard that automatically restores the prior relay when tests inject alternate instances. Integration tests assert shard-affinity ordering and backend swaps while relying on the guard to avoid leaking state into subsequent cases. Broadcast tests continue to verify base58 peer selection, ensuring the new guard does not perturb existing fanout accounting. Partition watch exposes sorted isolated peers and still tracks markers, and the suite now includes telemetry-disabled resets to guarantee behaviour without metrics compilation. These additions collectively reduce flakiness when toggling overlay backends in multi-shard simulations. With the guard pattern, we can introduce more aggressive fault injection without fearing stale relay pointers in global state. Upcoming work should layer WAN chaos harness hooks into these guard-backed tests so overlay restarts capture metrics under stress. We also need to expand partition-watch coverage into mixed-feature builds once telemetry probes for migration verification are available.

Documentation now highlights the overlay migrator in the README networking summary, pointing operators to the relevant runbooks for precise instructions. The governance release guide walks through the migration helper invocation, including bespoke path variants and cross-links back to operator procedures. Operator guidance details the commands, telemetry validation, and curl probes required after migrating peer stores into the new location. Storage documentation captures the in-house LSM architecture, column family layout, and migration tool usage so future maintainers understand the new defaults. Progress metrics were refreshed with the latest dependency snapshot counts, keeping stakeholders aligned with the dependency-sovereignty pivot timeline. Explorer modules switched to serde_json helpers for encoding and decoding view payloads, eliminating the prior codec dependency while preserving API ergonomics. These doc updates pave the way for automated link checking and inventory regeneration once CI wiring is complete. Next iterations should integrate the planned telemetry probes and dependency inventory regeneration cadence directly into the operator guides to close the loop between tooling and documentation.

------
https://chatgpt.com/codex/tasks/task_e_68dc191e4928832e89a2919441da33b6